### PR TITLE
Logger required on unhandled runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ The `crystal.react.implicits._` import will provide the following methods:
 * `<BackendScope[P, S]>.modStateIn[F](f: S => S): F[Unit]` - same as above. (Requires implicit `Async[F]`).
 * `<BackendScope[P, S]>.modStateWithPropsIn[F](f: (S, P) => S): F[Unit]` - (Requires implicit `Async[F]`).
 * `<SyncIO[A]>.toCB: CallbackTo[A]` - converts a `SyncIO` to `CallbackTo`.
-* `<F[A]>.runAsyncAndThenCB(cb: A => Callback): Callback` - When the resulting `Callback` is run, `F[A]` will be run asynchronously and its value passed to `cb`, whose returned `Callback` will be run then. (Requires implicit `Effect[F]`).
-* `<F[A]>.runAsyncAndForgetCB: Callback` - When the resulting `Callback` is run, `F[A]` will be run asynchronously and its value discarded. (Requires implicit `Effect[F]`).
-* `<F[Unit]>.runAsyncAndThenCB(cb: Callback): Callback` - When the resulting `Callback` is run, `F[Unit]` will be run asynchronously and when it completes, then `cb` will be run. (Requires implicit `Effect[F]`).
-* `<F[Unit]>.runAsyncCB: Callback` - When the resulting `Callback` is run, `F[Unit]` will be run asynchronously. (Requires implicit `Effect[F]`). Please note that the `Callback` will complete immediately.
+* `<F[A]>.runAsyncCB(cb: Either[Throwable, A] => F[Unit]): Callback` - When the resulting `Callback` is run, `F[A]` will be run asynchronously and its result will be handled by `cb`. (Requires implicit `Effect[F]`).
+* `<F[A]>.runAsyncAndThenCB(cb: Either[Throwable, A] => Callback): Callback` - When the resulting `Callback` is run, `F[A]` will be run asynchronously and its result will be handled by `cb`. The difference with `runAsyncCB` is that the result handler returns a `Callback` instead of `F[A]`. (Requires implicit `Effect[F]`).
+* `<F[A]>.runAsyncAndForgetCB: Callback` - When the resulting `Callback` is run, `F[A]` will be run asynchronously and its result will be ignored, as well as any errors it may raise. (Requires implicit `Effect[F]`).
+* `<F[Unit]>.runAsyncAndThenCB(cb: Callback, errorMsg: String?): Callback` - When the resulting `Callback` is run, `F[Unit]` will be run asynchronously. If it succeeds, then `cb` will be run. If it fails, `errorMsg` will be logged. (Requires implicit `Effect[F]` and `Logger[F]`).
+* `<F[Unit]>.runAsyncCB(errorMsg: String?): Callback` - When the resulting `Callback` is run, `F[Unit]` will be run asynchronously. If it fails, `errorMsg` will be logged. (Requires implicit `Effect[F]` and `Logger[F]`).
+
+Please note that in all cases the the `Callback` returned by `.runAsync*` will complete immediately.

--- a/js/src/main/scala/crystal/react/AppRoot.scala
+++ b/js/src/main/scala/crystal/react/AppRoot.scala
@@ -8,6 +8,7 @@ import scala.scalajs.js
 import crystal.ViewF
 import cats.effect.Effect
 import cats.effect.ContextShift
+import org.typelevel.log4cats.Logger
 
 object AppRoot {
   type Component[M] =
@@ -30,13 +31,18 @@ object AppRoot {
     )(implicit
       reusability: Reusability[M],
       effect:      Effect[F],
-      cs:          ContextShift[F]
+      cs:          ContextShift[F],
+      logger:      Logger[F]
     ): Component[M] =
       ScalaComponent
         .builder[Unit]
         .initialState(model)
         .render($ => render(ViewF.fromState($)))
-        .componentDidMount($ => onMount.toOption.map(_(ViewF.fromState($)).runAsyncCB).getOrEmpty)
+        .componentDidMount($ =>
+          onMount.toOption
+            .map(_(ViewF.fromState($)).runAsyncCB("Error in AppRoot.onMount."))
+            .getOrEmpty
+        )
         .componentWillUnmount($ => onUnmount.toOption.map(_($.state).runAsyncCB).getOrEmpty)
         .configure(Reusability.shouldComponentUpdate)
         .build

--- a/shared/src/main/scala/crystal/AppRootContext.scala
+++ b/shared/src/main/scala/crystal/AppRootContext.scala
@@ -31,5 +31,5 @@ trait AppRootContext[C] {
 
   def map[A, F[_]: LiftIO: Functor](f: C => A): F[A] = apply[F].map(f)
 
-  def withCtx[A](f: C => A): A = get.map(f).unsafeRunSync()
+  def runWithCtx[A](f: C => A): A = get.map(f).unsafeRunSync()
 }


### PR DESCRIPTION
When running an `Effect` through `runAsync*CB` methods, the cases where no handler was specified would result in errors being silently lost.

This PR introduces safety by requiring a `Logger` in the `runAsync*CB` methods that don't have a handler.

Also, it renames `AppRootContext.withCtx` => `.runWithCtx` with expresses more clearly that the code within is being run.

These are both breaking changes.

This is how `lucuma-ui` and `explore` like with this change. In both cases a bit more code was required to get the `Logger` into every call to `runAsync*CB`, but IMHO the added safety is worth it:

https://github.com/gemini-hlsw/lucuma-ui/pull/230
https://github.com/gemini-hlsw/explore/pull/655