### PR TITLE
Reuse.

### DIFF
--- a/js/src/main/scala/crystal/react/StreamRenderer.scala
+++ b/js/src/main/scala/crystal/react/StreamRenderer.scala
@@ -8,23 +8,18 @@ import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
 import crystal._
 import crystal.react.implicits._
+import crystal.react.reuse._
 
 object StreamRenderer {
-  type Props[A]     = Pot[A] => VdomNode
+  type Props[A]     = Pot[A] ==> VdomNode
   type Component[A] =
     CtorType.Props[Props[A], UnmountedWithRoot[Props[A], _, _, _]]
 
   type State[A] = Pot[A]
 
   def build[F[_]: Async: Dispatcher: Logger, A](
-    stream:      fs2.Stream[F, A]
-  )(implicit
-    reuse:       Reusability[A], // Used to derive Reusability[State[A]]
-    renderReuse: Reusability[Props[A]] = Reusability
-      .never[Props[A]]
-    // If a rerender is triggered, reusability should be controlled by enclosing component.
-    // We therefore don't apply reusability to the rendering function, but can be overriden.
-  ): Component[A] = {
+    stream:         fs2.Stream[F, A]
+  )(implicit reuse: Reusability[A] /* Used to derive Reusability[State[A]] */ ): Component[A] = {
     class Backend($ : BackendScope[Props[A], State[A]])
         extends StreamRendererBackend[F, A](stream) {
 

--- a/js/src/main/scala/crystal/react/StreamRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererMod.scala
@@ -9,12 +9,13 @@ import japgolly.scalajs.react.component.Generic.UnmountedWithRoot
 import japgolly.scalajs.react.{ Ref => _, _ }
 import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
+import crystal.react.reuse._
 
 import scala.concurrent.duration.FiniteDuration
 
 object StreamRendererMod {
 
-  type Props[F[_], A] = Pot[ViewF[F, A]] => VdomNode
+  type Props[F[_], A] = Pot[ViewF[F, A]] ==> VdomNode
 
   type State[A]           = Pot[A]
   type Component[F[_], A] =
@@ -26,15 +27,9 @@ object StreamRendererMod {
     ]]
 
   def build[F[_]: Async: Dispatcher: Logger, A](
-    stream:       fs2.Stream[F, A],
-    holdAfterMod: Option[FiniteDuration] = None
-  )(implicit
-    reuse:        Reusability[A], // Used to derive Reusability[State[A]]
-    renderReuse:  Reusability[Props[F, A]] = Reusability
-      .never[Props[F, A]]
-    // If a rerender is triggered, reusability should be controlled by enclosing component.
-    // We therefore don't apply reusability to the rendering function, but can be overriden.
-  ): Component[F, A] = {
+    stream:         fs2.Stream[F, A],
+    holdAfterMod:   Option[FiniteDuration] = None
+  )(implicit reuse: Reusability[A] /* Used to derive Reusability[State[A]] */ ): Component[F, A] = {
     class Backend($ : BackendScope[Props[F, A], State[A]])
         extends StreamRendererBackend[F, A](stream) {
 

--- a/js/src/main/scala/crystal/react/reuse/AppliedSyntax.scala
+++ b/js/src/main/scala/crystal/react/reuse/AppliedSyntax.scala
@@ -1,0 +1,136 @@
+package crystal.react.reuse
+
+import japgolly.scalajs.react.Reusability
+import scala.reflect.ClassTag
+
+protected trait AppliedSyntax {
+
+  /*
+   * Supports construction via the pattern `Reuse(reusedValue).by(valueWithReusability)`
+   */
+  class Applied[A](valueA: => A) {
+    val value: () => A = () => valueA
+
+    def by[R](reuseByR: R)(implicit classTagR: ClassTag[R], reuseR: Reusability[R]): Reuse[A] =
+      Reuse.by(reuseByR)(valueA)
+
+    def always: Reuse[A] = Reuse.by(())(valueA)
+  }
+
+  implicit class AppliedFn2Ops[A, R, S, B](aa: Applied[A])(implicit ev: A =:= ((R, S) => B)) {
+    /*
+     * Given a (R, S) => B, instantiate R and build a S ==> B.
+     */
+    def apply(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[S => B] =
+      Reuse.by(r)(s => ev(aa.value())(r, s))
+
+    /*
+     * Given a (R, S) => B, instantiate R and S and build a Reuse[B].
+     */
+    def apply(
+      r:         R,
+      s:         S
+    )(implicit
+      classTagR: ClassTag[(R, S)],
+      reuseR:    Reusability[(R, S)]
+    ): Reuse[B] =
+      Reuse.by((r, s))(ev(aa.value())(r, s))
+  }
+
+  implicit class AppliedFn3Ops[A, R, S, T, B](aa: Applied[A])(implicit ev: A =:= ((R, S, T) => B)) {
+    /*
+     * Given a (R, S, T) => B , instantiate R and build a (S, T) ==> B.
+     */
+    def apply(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[(S, T) => B] =
+      Reuse.by(r)((s, t) => ev(aa.value())(r, s, t))
+
+    /*
+     * Given a (R, S, T) => B , instantiate R and S and build a T ==> B.
+     */
+    def apply(
+      r:          R,
+      s:          S
+    )(implicit
+      classTagRS: ClassTag[(R, S)],
+      reuseR:     Reusability[(R, S)]
+    ): Reuse[T => B] =
+      Reuse.by((r, s))(t => ev(aa.value())(r, s, t))
+
+    /*
+     * Given a (R, S, T) => B , instantiate R, S and T and build a Reuse[B].
+     */
+    def apply(
+      r:          R,
+      s:          S,
+      t:          T
+    )(implicit
+      classTagRS: ClassTag[(R, S, T)],
+      reuseR:     Reusability[(R, S, T)]
+    ): Reuse[B] =
+      Reuse.by((r, s, t))(ev(aa.value())(r, s, t))
+  }
+
+  implicit class AppliedFn4Ops[A, R, S, T, U, B](aa: Applied[A])(implicit
+    ev:                                              A =:= ((R, S, T, U) => B)
+  ) {
+    /*
+     * Given a (R, S, T, U) => B , instantiate R and build a (S, T, U) ==> B.
+     */
+    def apply(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[(S, T, U) => B] =
+      Reuse.by(r)((s, t, u) => ev(aa.value())(r, s, t, u))
+
+    /*
+     * Given a (R, S, T, U) => B , instantiate R and S and build a (T, U) ==> B.
+     */
+    def apply(
+      r:          R,
+      s:          S
+    )(implicit
+      classTagRS: ClassTag[(R, S)],
+      reuseR:     Reusability[(R, S)]
+    ): Reuse[(T, U) => B] =
+      Reuse.by((r, s))((t, u) => ev(aa.value())(r, s, t, u))
+
+    /*
+     * Given a (R, S, T, U) => B , instantiate R, S and T and build a U ==> B.
+     */
+    def apply(
+      r:          R,
+      s:          S,
+      t:          T
+    )(implicit
+      classTagRS: ClassTag[(R, S, T)],
+      reuseR:     Reusability[(R, S, T)]
+    ): Reuse[U => B] =
+      Reuse.by((r, s, t))(u => ev(aa.value())(r, s, t, u))
+
+    /*
+     * Given a (R, S, T, U) => B , instantiate R, S, T and U and build a Reuse[B].
+     */
+    def apply(
+      r:          R,
+      s:          S,
+      t:          T,
+      u:          U
+    )(implicit
+      classTagRS: ClassTag[(R, S, T, U)],
+      reuseR:     Reusability[(R, S, T, U)]
+    ): Reuse[B] =
+      Reuse.by((r, s, t, u))(ev(aa.value())(r, s, t, u))
+  }
+}

--- a/js/src/main/scala/crystal/react/reuse/CurrySyntax.scala
+++ b/js/src/main/scala/crystal/react/reuse/CurrySyntax.scala
@@ -1,0 +1,90 @@
+package crystal.react.reuse
+
+import japgolly.scalajs.react.Reusability
+import scala.reflect.ClassTag
+
+protected trait CurrySyntax {
+  /*
+   * Support instantiating the parameter of a R ==> B via the `.curry(...)` method.
+   */
+  implicit class ReuseFn1Ops[A, R, B](ra: Reuse[A])(implicit ev: A =:= (R => B)) {
+    def curry(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[(ra.B, R)],
+      reuseR:    Reusability[R]
+    ): Reuse[B] = {
+      implicit val rB = ra.reusability
+      Reuse.by((ra.reuseBy, r))(ev(ra.value())(r))
+    }
+  }
+
+  /*
+   * Support instantiating some or all of the parameters of a (R, S) ==> B via
+   * the `.curry(...)` method.
+   */
+  implicit class ReuseFn2Ops[A, R, S, B](ra: Reuse[A])(implicit ev: A =:= ((R, S) => B)) {
+    def curry(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[(ra.B, R)],
+      reuseR:    Reusability[R]
+    ): Reuse[S => B] = {
+      implicit val rB = ra.reusability
+      Reuse.by((ra.reuseBy, r))(s => ev(ra.value())(r, s))
+    }
+  }
+
+  // Auto tupling/untupling to support (R, S) ==> B syntax. Since ==> is a type alias,
+  // (R, S) is interpreted as a tuple in that case.
+  implicit def tupledReuseFn2[A, R, S, B](ra: Reuse[A])(implicit
+    ev:                                       A =:= ((R, S) => B)
+  ): (R, S) ==> B =
+    ra.map(f => ev(f).tupled)
+
+  implicit def untupledReuseFn2[A, R, S, B](ra: Reuse[A])(implicit
+    ev:                                         A =:= (((R, S)) => B)
+  ): Reuse[(R, S) => B] =
+    ra.map(f => (r, s) => ev(f)((r, s)))
+
+  implicit class ReuseFn2TupledOps[A, R, S, B](ra: Reuse[A])(implicit ev: A =:= (((R, S)) => B)) {
+    def curry(r: R)(implicit reuseR: Reusability[R]): Reuse[S => B] =
+      (ra: Reuse[(R, S) => B]).curry(r)
+  }
+
+  /*
+   * Support instantiating some or all of the parameters of a (R, S, T) ==> B via
+   * the `.curry(...)` method.
+   */
+  implicit class ReuseFn3Ops[A, R, S, T, B](ra: Reuse[A])(implicit ev: A =:= ((R, S, T) => B)) {
+    def curry(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[(ra.B, R)],
+      reuseR:    Reusability[R]
+    ): Reuse[(S, T) => B] = {
+      implicit val rB = ra.reusability
+      Reuse.by((ra.reuseBy, r))((s, t) => ev(ra.value())(r, s, t))
+    }
+  }
+
+  // Auto tupling/untupling to support (R, S, T) ==> B syntax. Since ==> is a type alias,
+  // (R, S, T) is interpreted as a tuple in that case.
+  implicit def tupledReuseFn3[A, R, S, T, B](ra: Reuse[A])(implicit
+    ev:                                          A =:= ((R, S, T) => B)
+  ): (R, S, T) ==> B =
+    ra.map(f => ev(f).tupled)
+
+  implicit def untupledReuseFn3[A, R, S, T, B](ra: Reuse[A])(implicit
+    ev:                                            A =:= (((R, S, T)) => B)
+  ): Reuse[(R, S, T) => B] =
+    ra.map(f => (r, s, t) => ev(f)((r, s, t)))
+
+  implicit class ReuseFn3TupledOps[A, R, S, T, B](ra: Reuse[A])(implicit
+    ev:                                               A =:= (((R, S, T)) => B)
+  ) {
+    def curry(r: R)(implicit reuseR: Reusability[R]): Reuse[(S, T) => B] =
+      (ra: Reuse[(R, S, T) => B]).curry(r)
+  }
+
+}

--- a/js/src/main/scala/crystal/react/reuse/CurryingSyntax.scala
+++ b/js/src/main/scala/crystal/react/reuse/CurryingSyntax.scala
@@ -1,0 +1,103 @@
+package crystal.react.reuse
+
+import japgolly.scalajs.react.Reusability
+import scala.reflect.ClassTag
+
+/*
+ * Supports construction via the pattern `Reuse.currying(valueWithReusability : R).in( (R[, ...]) => B )`
+ * and similar for higher arities.
+ */
+trait CurryingSyntax {
+  class Curried1[R](val r: R) {
+    /*
+     * Add another curried value.
+     */
+    def and[S](s: S): Curried2[R, S] = new Curried2(r, s)
+
+    /*
+     * Given R and a R => B, build a Reuse[B].
+     */
+    def in[B](
+      fn:        R => B
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[B] =
+      Reuse.by(r)(fn(r))
+
+    /*
+     * Given R and a (R, S) => B, build a S ==> B.
+     */
+    def in[S, B](
+      fn:        (R, S) => B
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[S => B] =
+      Reuse.by(r)(s => fn(r, s))
+
+    /*
+     * Given R and a (R, S, T) => B, build a (S, T) ==> B.
+     */
+    def in[S, T, B](
+      fn:        (R, S, T) => B
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[(S, T) => B] =
+      Reuse.by(r)((s, t) => fn(r, s, t))
+  }
+
+  class Curried2[R, S](val r: R, val s: S) {
+    /*
+     * Add another curried value.
+     */
+    def and[T](t: T): Curried3[R, S, T] = new Curried3(r, s, t)
+
+    /*
+     * Given R, S and a (R, S) => B, build a Reuse[B].
+     */
+    def in[B](
+      fn:        (R, S) => B
+    )(implicit
+      classTagR: ClassTag[(R, S)],
+      reuseR:    Reusability[(R, S)]
+    ): Reuse[B] =
+      Reuse.by((r, s))(fn(r, s))
+
+    /*
+     * Given R, S and a (R, S, T) => B, build a T ==> B.
+     */
+    def in[T, B](
+      fn:        (R, S, T) => B
+    )(implicit
+      classTagR: ClassTag[(R, S)],
+      reuseR:    Reusability[(R, S)]
+    ): Reuse[T => B] =
+      Reuse.by((r, s))(t => fn(r, s, t))
+  }
+
+  class Curried3[R, S, T](val r: R, val s: S, val t: T) {
+    /*
+     * Given R, S, T and a (R, S, T) => B, build a Reuse[B].
+     */
+    def in[B](
+      fn:        (R, S, T) => B
+    )(implicit
+      classTagR: ClassTag[(R, S, T)],
+      reuseR:    Reusability[(R, S, T)]
+    ): Reuse[B] =
+      Reuse.by((r, s, t))(fn(r, s, t))
+
+    /*
+     * Given R, S, T and a (R, S, T, U) => B, build a U ==> B.
+     */
+    def in[U, B](
+      fn:        (R, S, T, U) => B
+    )(implicit
+      classTagR: ClassTag[(R, S, T)],
+      reuseR:    Reusability[(R, S, T)]
+    ): Reuse[U => B] =
+      Reuse.by((r, s, t))(u => fn(r, s, t, u))
+  }
+}

--- a/js/src/main/scala/crystal/react/reuse/ReusableInterop.scala
+++ b/js/src/main/scala/crystal/react/reuse/ReusableInterop.scala
@@ -1,0 +1,40 @@
+package crystal.react.reuse
+
+/*
+ * Convert (A[, B, ...]) ==> Z into A ~=> (B [~=> ...] ~=> Z).
+ */
+protected trait ReusableInterop {
+  import japgolly.scalajs.react._
+
+  // Fn1
+  implicit def toReusableFn1[A, R, B](ra: Reuse[A])(implicit ev: A =:= (R => B)): R ~=> B =
+    Reusable.implicitly(new Fn1(ra.map(ev)))
+
+  class Fn1[R, B](val f: Reuse[R => B]) extends Function1[R, B] {
+    def apply(r: R): B = f.value()(r)
+  }
+  implicit def reusablityFn1[R, B]: Reusability[Fn1[R, B]] = Reusability.by(_.f)
+
+  // Fn2
+  implicit def toReusableFn2[A, R: Reusability, S, B](ra: Reuse[A])(implicit
+    ev:                                                   A =:= ((R, S) => B)
+  ): R ~=> (S ~=> B) =
+    Reusable.implicitly(new Fn2(ra.map(ev)))
+
+  class Fn2[R: Reusability, S, B](val f: Reuse[(R, S) => B]) extends Function1[R, S ~=> B] {
+    def apply(r: R): S ~=> B = f.curry(r)
+  }
+  implicit def reusablityFn2[R, S, B]: Reusability[Fn2[R, S, B]] = Reusability.by(_.f)
+
+  // Fn3
+  implicit def toReusableFn3[A, R: Reusability, S: Reusability, T, B](ra: Reuse[A])(implicit
+    ev:                                                                   A =:= ((R, S, T) => B)
+  ): R ~=> (S ~=> (T ~=> B)) =
+    Reusable.implicitly(new Fn3(ra.map(ev)))
+
+  class Fn3[R: Reusability, S: Reusability, T, B](val f: Reuse[(R, S, T) => B])
+      extends Function1[R, S ~=> (T ~=> B)] {
+    def apply(r: R): S ~=> (T ~=> B) = f.curry(r)
+  }
+  implicit def reusablityFn3[R, S, T, B]: Reusability[Fn3[R, S, T, B]] = Reusability.by(_.f)
+}

--- a/js/src/main/scala/crystal/react/reuse/Reuse.scala
+++ b/js/src/main/scala/crystal/react/reuse/Reuse.scala
@@ -1,0 +1,125 @@
+package crystal.react.reuse
+
+import japgolly.scalajs.react.Reusability
+import scala.reflect.ClassTag
+
+/*
+ * Wraps a (lazy) `value` of type `A` and an associated `reuseBy` of a hidden type `B`,
+ * delegating `Reusability` to `Reusability[B]`.
+ *
+ * In other words, delegates existential `Reusability` of instances of `A` to an existing
+ * universal `Reusability` of `B`, while associating instances of `A` to instances of `B`.
+ *
+ * It's particularly useful to provide `Reusability` for functions or VDOM elements.
+ *
+ * When used for functions, it differs from `scalajs-react`'s `Reusable.fn` mainly in that
+ * the reference equality of the wrapped function is not checked: `Reusability` is
+ * computed solely based on the provided `reuseBy` value. This allows using inline idioms
+ * like:
+ *
+ *   `Component(Reuse.currying(props).in( (props, text: String) => ...: VdomNode)`
+ *
+ * in which `Component` would expect a `Reuse[String => VdomNode]` as a parameter. In this
+ * case, the wrapped `String => VdomNode` function is reused as long as `props` can be reused.
+ *
+ * A number of convenience constructors, methods and implicits are provided in order to
+ * support a wide variety of use cases. Notably:
+ *  * `(A, B, ...) ==> Z` is a type alias for `Reusable[(A, B, ...) => Z]`.
+ *  * `A` is automatically unwrapped when expecting `A` and a `Reuse[A]` is provided.
+ *  * A `Reuse[A]` is automatically converted to `Reusable[A]` when needed.
+ *
+ */
+trait Reuse[A] {
+  type B
+
+  val value: () => A
+
+  protected[reuse] val reuseBy: B // We need to store it to combine into tuples when currying.
+
+  protected[reuse] implicit val ClassTag: ClassTag[B]
+
+  protected[reuse] implicit val reusability: Reusability[B]
+
+  def map[C](f: A => C): Reuse[C] = Reuse.by(reuseBy)(f(value()))
+}
+
+object Reuse extends AppliedSyntax with CurryingSyntax with CurrySyntax with ReusableInterop {
+  implicit def toA[A](reuseFn: Reuse[A]): A = reuseFn.value()
+
+  implicit def reusability[A]: Reusability[Reuse[A]] =
+    Reusability.apply((reuseA, reuseB) =>
+      if (reuseA.ClassTag == reuseB.ClassTag)
+        reuseA.reusability.test(reuseA.reuseBy, reuseB.reuseBy.asInstanceOf[reuseA.B]) &&
+        reuseB.reusability.test(reuseA.reuseBy.asInstanceOf[reuseB.B], reuseB.reuseBy)
+      else false
+    )
+
+  /*
+   * Constructs a `Reuse[A]` by using the pattern `Reuse.by(valueWithReusability)(reusedValue)`.
+   */
+  def by[A, R](reuseByR: R) = new AppliedBy(reuseByR)
+
+  def always[A](a: A): Reuse[A] = by(())(a)(implicitly[ClassTag[Unit]], Reusability.always)
+
+  def never[A](a: A): Reuse[A] = by(())(a)(implicitly[ClassTag[Unit]], Reusability.never)
+
+  /*
+   * Constructs a `Reuse[A]` by using the pattern `Reuse(reusedValue).by(valueWithReusability)`.
+   */
+  def apply[A](value: => A): Applied[A] = new Applied(value)
+
+  /*
+   * Constructs a reusable function by using the pattern
+   * `Reuse.currying(valueWithReusability : R).in( (R[, ...]) => B )`.
+   */
+  def currying[R](r: R): Curried1[R] = new Curried1(r)
+
+  /*
+   * Constructs a reusable function by using the pattern
+   * `Reuse.currying(value1WithReusability : R, value2: S).in( (R, S[, ...]) => B )`.
+   */
+  def currying[R, S](r: R, s: S): Curried2[R, S] = new Curried2(r, s)
+
+  /*
+   * Constructs a reusable function by using the pattern
+   * `Reuse.currying(value1WithReusability : R, value2: S, value3: T).in( (R, S, T[, ...]) => B )`.
+   */
+  def currying[R, S, T](r: R, s: S, t: T): Curried3[R, S, T] = new Curried3(r, s, t)
+
+  /*
+   * Supports construction via the pattern `Reuse.by(valueWithReusability)(reusedValue)`
+   */
+  class AppliedBy[R](reuseByR: R) {
+    /*
+     * Auto-tuple 2-parameter function in order to be able to use (S, T) ==> B notation
+     * when constructing via the pattern `Reuse.by(value)(function)`.
+     */
+    def apply[A, S, T, B](
+      fn:                 (S, T) => B
+    )(implicit classTagR: ClassTag[R], reuseR: Reusability[R]): (S, T) ==> B =
+      apply(fn.tupled)
+
+    /*
+     * Auto-tuple 3-parameter function in order to be able to use (S, T, U) ==> B notation
+     * when constructing via the pattern `Reuse.by(value)(function)`.
+     */
+    def apply[A, S, T, U, B](
+      fn:                 (S, T, U) => B
+    )(implicit classTagR: ClassTag[R], reuseR: Reusability[R]): (S, T, U) ==> B =
+      apply(fn.tupled)
+
+    def apply[A](valueA: => A)(implicit classTagR: ClassTag[R], reuseR: Reusability[R]): Reuse[A] =
+      new Reuse[A] {
+        type B = R
+
+        val value = () => valueA
+
+        protected[reuse] val reuseBy = reuseByR
+
+        protected[reuse] val ClassTag = classTagR
+
+        protected[reuse] val reusability = reuseR
+      }
+  }
+
+}

--- a/js/src/main/scala/crystal/react/reuse/package.scala
+++ b/js/src/main/scala/crystal/react/reuse/package.scala
@@ -1,0 +1,128 @@
+package crystal.react
+
+import japgolly.scalajs.react.Reusability
+import scala.reflect.ClassTag
+
+package object reuse {
+  type ==>[A, B] = Reuse[A => B]
+
+  implicit class AnyReuseOps[A](val a: A) extends AnyVal {
+    def reuseAlways: Reuse[A] = Reuse.always(a)
+
+    def reuseNever: Reuse[A] = Reuse.never(a)
+
+    /*
+     * Implements the idiom:
+     *   `a.curryReusing( (A, B) => C )`
+     * to create a `Reusable[B => C]` with `Reusability[A]`.
+     *
+     * Works for other arities too, as implemented in `Reuse.Curried1`.
+     */
+    def curryReusing: Reuse.Curried1[A] = Reuse.currying(a)
+  }
+
+  implicit class Tuple2ReuseOps[R, S](val t: (R, S)) extends AnyVal {
+    /*
+     * Implements the idiom:
+     *   `(a, b).curryReusing( (A, B, C) => D )`
+     * to create a `Reusable[C => D]` with `Reusability[(A, B)]`.
+     *
+     * Works for other arities too, as implemented in `Reuse.Curried2`.
+     */
+    def curryReusing: Reuse.Curried2[R, S] = Reuse.currying(t._1, t._2)
+  }
+
+  implicit class Tuple3ReuseOps[R, S, T](val t: (R, S, T)) extends AnyVal {
+    /*
+     * Implements the idiom:
+     *   `(a, b, c).curryReusing( (A, B, C, D) => E )`
+     * to create a `Reusable[D => E]` with `Reusability[(A, B, C)]`.
+     *
+     * Works for other arities too, as implemented in `Reuse.Curried3`.
+     */
+    def curryReusing: Reuse.Curried3[R, S, T] = Reuse.currying(t._1, t._2, t._3)
+  }
+
+  implicit class Fn1ReuseOps[R, B](val fn: R => B) extends AnyVal {
+    /*
+     * Implements the idiom:
+     *   `(R => B).reuseCurrying(r)`
+     * to create a `Reusable[B]` with `Reusability[R]`.
+     */
+    def reuseCurrying(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[B] = Reuse.currying(r).in(fn)
+  }
+
+  implicit class Fn2ReuseOps[R, S, B](val fn: (R, S) => B) extends AnyVal {
+    /*
+     * Implements the idiom:
+     *   `((R, S) => B).reuseCurrying(r)`
+     * to create a `Reusable[S => B]` with `Reusability[R]`.
+     */
+    def reuseCurrying(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[S => B] = Reuse.currying(r).in(fn)
+
+    /*
+     * Implements the idiom:
+     *   `((R, S) => B).reuseCurrying(r, s)`
+     * to create a `Reusable[B]` with `Reusability[(R, S)]`.
+     */
+    def reuseCurrying(
+      r:         R,
+      s:         S
+    )(implicit
+      classTagR: ClassTag[(R, S)],
+      reuseR:    Reusability[(R, S)]
+    ): Reuse[B] = Reuse.currying(r, s).in(fn)
+  }
+
+  implicit class Fn3ReuseOps[R, S, T, B](val fn: (R, S, T) => B) extends AnyVal {
+    /*
+     * Implements the idiom:
+     *   `((R, S, T) => B).reuseCurrying(r)`
+     * to create a `Reusable[(S, T) => B]` with `Reusability[R]`.
+     */
+    def reuseCurrying(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[(S, T) => B] = Reuse.currying(r).in(fn)
+
+    /*
+     * Implements the idiom:
+     *   `((R, S, T) => B).reuseCurrying(r, s)`
+     * to create a `Reusable[T => B]` with `Reusability[(R, S)]`.
+     */
+    def reuseCurrying(
+      r:         R,
+      s:         S
+    )(implicit
+      classTagR: ClassTag[(R, S)],
+      reuseR:    Reusability[(R, S)]
+    ): Reuse[T => B] = Reuse.currying(r, s).in(fn)
+
+    /*
+     * Implements the idiom:
+     *   `((R, S, T) => B).reuseCurrying(r, s, t)`
+     * to create a `Reusable[B]` with `Reusability[(R, S, T)]`.
+     */
+    def reuseCurrying(
+      r:         R,
+      s:         S,
+      t:         T
+    )(implicit
+      classTagR: ClassTag[(R, S, T)],
+      reuseR:    Reusability[(R, S, T)]
+    ): Reuse[B] = Reuse.currying(r, s, t).in(fn)
+  }
+
+}

--- a/js/src/test/scala/crystal/react/reuse/ReuseSpec.scala
+++ b/js/src/test/scala/crystal/react/reuse/ReuseSpec.scala
@@ -1,0 +1,169 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package crystal.react.reuse
+
+import japgolly.scalajs.react.Reusability
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop._
+
+final class ReuseSpec extends ScalaCheckSuite {
+
+  test("Reuse(function).by(value) syntax") {
+    forAll { (u1: String, u2: String) =>
+      val r1: Double ==> String = Reuse((q: Double) => s"$q $u1").by(u1)
+      val r2: Double ==> String = Reuse((q: Double) => s"$q $u2").by(u2)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[String]].test(u1, u2)
+      )
+    }
+  }
+
+  test("Reuse.by(value)(function) syntax") {
+    forAll { (u1: String, u2: String) =>
+      val r1: Double ==> String = Reuse.by(u1)((q: Double) => s"$q $u1")
+      val r2: Double ==> String = Reuse.by(u2)((q: Double) => s"$q $u2")
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[String]].test(u1, u2)
+      )
+    }
+  }
+
+  def format(units: String, q: Double): String = s"$q $units"
+
+  def format2(units: String, prefix: String, q: Double): String = s"$prefix $q $units"
+
+  // Currying
+  test("Reuse(function)(parameter) syntax") {
+    forAll { (u1: String, u2: String) =>
+      val r1: Double ==> String = Reuse(format _)(u1)
+      val r2: Double ==> String = Reuse(format _)(u2)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[String]].test(u1, u2)
+      )
+    }
+  }
+
+  test("Reuse(function2)(parameter) syntax") {
+    forAll { (u1: String, u2: String) =>
+      val r1: (String, Double) ==> String = Reuse(format2 _)(u1)
+      val r2: (String, Double) ==> String = Reuse(format2 _)(u2)
+      assertEquals(implicitly[Reusability[(String, Double) ==> String]].test(r1, r2),
+                   implicitly[Reusability[String]].test(u1, u2)
+      )
+    }
+  }
+
+  test("Reuse(function2)(parameter1, parameter2) syntax") {
+    forAll { (u1: String, p1: String, u2: String, p2: String) =>
+      val r1: Double ==> String = Reuse(format2 _)(u1, p1)
+      val r2: Double ==> String = Reuse(format2 _)(u2, p2)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[(String, String)]].test((u1, p1), (u2, p2))
+      )
+    }
+  }
+
+  test("Reuse(function2)(parameter1).curry(parameter2) syntax") {
+    forAll { (u1: String, p1: String, u2: String, p2: String) =>
+      val r1: Double ==> String = Reuse(format2 _)(u1).curry(p1)
+      val r2: Double ==> String = Reuse(format2 _)(u2).curry(p2)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[(String, String)]].test((u1, p1), (u2, p2))
+      )
+    }
+  }
+
+  test("Reuse.currying(paramter).in(function) syntax") {
+    forAll { (u1: String, u2: String) =>
+      val r1: Double ==> String = Reuse.currying(u1).in(format _)
+      val r2: Double ==> String = Reuse.currying(u2).in(format _)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[String]].test(u1, u2)
+      )
+    }
+  }
+
+  test("Reuse.currying(parameter1, parameter2).in(function2) syntax") {
+    forAll { (u1: String, p1: String, u2: String, p2: String) =>
+      val r1: Double ==> String = Reuse.currying(u1, p1).in(format2 _)
+      val r2: Double ==> String = Reuse.currying(u2, p2).in(format2 _)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[(String, String)]].test((u1, p1), (u2, p2))
+      )
+    }
+  }
+
+  test("function.reuseCurrying(paramter) syntax") {
+    forAll { (u1: String, u2: String) =>
+      val r1: Double ==> String = (format _).reuseCurrying(u1)
+      val r2: Double ==> String = (format _).reuseCurrying(u2)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[String]].test(u1, u2)
+      )
+    }
+  }
+
+  test("function2.reuseCurrying(paramter1).curry(parameter2) syntax") {
+    forAll { (u1: String, p1: String, u2: String, p2: String) =>
+      val r1: Double ==> String = (format2 _).reuseCurrying(u1).curry(p1)
+      val r2: Double ==> String = (format2 _).reuseCurrying(u2).curry(p2)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[(String, String)]].test((u1, p1), (u2, p2))
+      )
+    }
+  }
+
+  test("function2.reuseCurrying(paramter1, parameter2) syntax") {
+    forAll { (u1: String, p1: String, u2: String, p2: String) =>
+      val r1: Double ==> String = (format2 _).reuseCurrying(u1, p1)
+      val r2: Double ==> String = (format2 _).reuseCurrying(u2, p2)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[(String, String)]].test((u1, p1), (u2, p2))
+      )
+    }
+  }
+
+  test("parameter.curryReusing.in(function) syntax") {
+    forAll { (u1: String, u2: String) =>
+      val r1: Double ==> String = u1.curryReusing.in(format _)
+      val r2: Double ==> String = u2.curryReusing.in(format _)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[String]].test(u1, u2)
+      )
+    }
+  }
+
+  test("parameter1.curryReusing.in(function2).curry(parameter2) syntax") {
+    forAll { (u1: String, p1: String, u2: String, p2: String) =>
+      val r1: Double ==> String = u1.curryReusing.in(format2 _).curry(p1)
+      val r2: Double ==> String = u2.curryReusing.in(format2 _).curry(p2)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[(String, String)]].test((u1, p1), (u2, p2))
+      )
+    }
+  }
+
+  test("(parameter1, paramter2).curryReusing.in(function2) syntax") {
+    forAll { (u1: String, p1: String, u2: String, p2: String) =>
+      val r1: Double ==> String = (u1, p1).curryReusing.in(format2 _)
+      val r2: Double ==> String = (u2, p2).curryReusing.in(format2 _)
+      assertEquals(implicitly[Reusability[Double ==> String]].test(r1, r2),
+                   implicitly[Reusability[(String, String)]].test((u1, p1), (u2, p2))
+      )
+    }
+  }
+
+  implicit val reuseDouble = Reusability.double(0.1)
+
+  test("(parameter1, paramter2).curryReusing.in(function2).curry(parameter3) syntax") {
+    forAll { (u1: String, p1: String, d1: Double, u2: String, p2: String, d2: Double) =>
+      val r1: Reuse[String] = (u1, p1).curryReusing.in(format2 _).curry(d1)
+      val r2: Reuse[String] = (u2, p2).curryReusing.in(format2 _).curry(d2)
+      assertEquals(
+        implicitly[Reusability[Reuse[String]]].test(r1, r2),
+        implicitly[Reusability[(String, String, Double)]].test((u1, p1, d1), (u2, p2, d2))
+      )
+    }
+  }
+}


### PR DESCRIPTION
From the Scaladoc:

A `Reuse[A]`: 

Wraps a (lazy) `value` of type `A` and an associated `reuseBy` of a hidden type `B`, delegating `Reusability` to `Reusability[B]`.

In other words, delegates existential `Reusability` of instances of `A` to an existing universal `Reusability` of `B`, while associating instances of `A` to instances of `B`.

It's particularly useful to provide `Reusability` for functions or VDOM elements.

When used for functions, it differs from `scalajs-react`'s `Reusable.fn` mainly in that the reference equality of the wrapped function is not checked: `Reusability` is computed solely based on the provided `reuseBy` value. This allows using inline idioms like: 
``` scala
  Component(Reuse.currying(props).in( (props, text: String) => ...: VdomNode)
```
in which `Component` would expect a `Reuse[String => VdomNode]` as a parameter. In this case, the wrapped `String => VdomNode` function is reused as long as `props` can be reused.

A number of convenience constructors, methods and implicits are provided in order to support a wide variety of use cases. Notably:
 * `(A, B, ...) ==> Z` is a type alias for `Reusable[(A, B, ...) => Z]`.
 * `A` is automatically unwrapped when expecting `A` and a `Reuse[A]` is provided.
 * A `Reuse[A]` is automatically converted to `Reusable[A]` when needed.

---

The rendering functions passed to `StreamRender` and `StreamRenderMod` now have to be a `Reuse` function.