### PR TITLE
Embrace SyncIO + Reuse everywhere.

### DIFF
--- a/js/src/main/scala/crystal/ComponentTypesForPlatform.scala
+++ b/js/src/main/scala/crystal/ComponentTypesForPlatform.scala
@@ -1,6 +1,6 @@
 package crystal
 
 trait ComponentTypesForPlatform extends ComponentTypes {
-  type StreamRenderer[A]          = react.StreamRenderer.Component[A]
-  type StreamRendererMod[F[_], A] = react.StreamRendererMod.Component[F, A]
+  type StreamRenderer[A]    = react.StreamRenderer.Component[A]
+  type StreamRendererMod[A] = react.StreamRendererMod.Component[A]
 }

--- a/js/src/main/scala/crystal/react/ContextProvider.scala
+++ b/js/src/main/scala/crystal/react/ContextProvider.scala
@@ -1,24 +1,27 @@
 package crystal.react
 
 import crystal.ViewF
-import cats.effect.Async
 import implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
+import cats.effect.SyncIO
+import crystal.react.reuse.Reuse
 
-object ContextProvider {
+object ContextProviderSyncIO {
 
-  @inline def apply[F[_]] = new Apply[F]
-
-  class Apply[F[_]] {
-    def apply[C](ctx:        Ctx[F, C], initCtx:    C)(
-      render:                VdomNode
-    )(implicit reusabilityC: Reusability[C], async: Async[F]): StateComponent[C] =
-      ScalaComponent
-        .builder[Unit]
-        .initialState(initCtx)
-        .render($ => ctx.provide(ViewF.fromState[F]($))(render))
-        .configure(Reusability.shouldComponentUpdate)
-        .build
+  class Backend[C](ctx: Ctx[SyncIO, C])($ : BackendScope[Reuse[VdomNode], C]) {
+    def render(props: Reuse[VdomNode]) =
+      ctx.provide(ViewF.fromStateSyncIO($))(props)
   }
+
+  def apply[C](ctx: Ctx[SyncIO, C], initCtx: C)(implicit
+    reusabilityC:   Reusability[C]
+  ): ContextComponent[C] =
+    ScalaComponent
+      .builder[Reuse[VdomNode]]
+      .initialState(initCtx)
+      .backend($ => new Backend(ctx)($))
+      .renderBackend
+      .configure(Reusability.shouldComponentUpdate)
+      .build
 }

--- a/js/src/main/scala/crystal/react/StateProvider.scala
+++ b/js/src/main/scala/crystal/react/StateProvider.scala
@@ -2,22 +2,24 @@ package crystal.react
 
 import crystal.ViewF
 import implicits._
-import cats.effect.Async
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
+import cats.effect.SyncIO
+import crystal.react.reuse.Reuse
 
-object StateProvider {
-  @inline def apply[F[_]] = new Apply[F]
+object StateProviderSyncIO {
 
-  class Apply[F[_]] {
-    def apply[M](model:      M)(
-      render:                ViewF[F, M] => VdomNode
-    )(implicit reusabilityM: Reusability[M], async: Async[F]): StateComponent[M] =
-      ScalaComponent
-        .builder[Unit]
-        .initialState(model)
-        .render($ => render(ViewF.fromState($)))
-        .configure(Reusability.shouldComponentUpdate)
-        .build
+  class Backend[M]($ : BackendScope[Reuse[ViewF[SyncIO, M] => VdomNode], M]) {
+    def render(props: Reuse[ViewF[SyncIO, M] => VdomNode]) =
+      props(ViewF.fromStateSyncIO($))
   }
+
+  def apply[M](model: M)(implicit reusabilityM: Reusability[M]): StateComponent[M] =
+    ScalaComponent
+      .builder[Reuse[ViewF[SyncIO, M] => VdomNode]]
+      .initialState(model)
+      .backend($ => new Backend($))
+      .renderBackend
+      .configure(Reusability.shouldComponentUpdate)
+      .build
 }

--- a/js/src/main/scala/crystal/react/StreamRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererMod.scala
@@ -2,9 +2,9 @@ package crystal.react
 
 import crystal._
 import crystal.react.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.effect.std.Dispatcher
-import cats.syntax.all._
 import japgolly.scalajs.react.component.Generic.UnmountedWithRoot
 import japgolly.scalajs.react.{ Ref => _, _ }
 import japgolly.scalajs.react.vdom.html_<^._
@@ -15,22 +15,24 @@ import scala.concurrent.duration.FiniteDuration
 
 object StreamRendererMod {
 
-  type Props[F[_], A] = Pot[ViewF[F, A]] ==> VdomNode
+  type Props[A] = Pot[ViewF[SyncIO, A]] ==> VdomNode
 
-  type State[A]           = Pot[A]
-  type Component[F[_], A] =
-    CtorType.Props[Props[F, A], UnmountedWithRoot[
-      Props[F, A],
+  type State[A]     = Pot[A]
+  type Component[A] =
+    CtorType.Props[Props[A], UnmountedWithRoot[
+      Props[A],
       _,
       _,
       _
     ]]
 
   def build[F[_]: Async: Dispatcher: Logger, A](
-    stream:         fs2.Stream[F, A],
-    holdAfterMod:   Option[FiniteDuration] = None
-  )(implicit reuse: Reusability[A] /* Used to derive Reusability[State[A]] */ ): Component[F, A] = {
-    class Backend($ : BackendScope[Props[F, A], State[A]])
+    stream:       fs2.Stream[F, A],
+    holdAfterMod: Option[FiniteDuration] = None
+  )(implicit
+    reuse:        Reusability[A] /* Used to derive Reusability[State[A]] */
+  ): Component[A] = {
+    class Backend($ : BackendScope[Props[A], State[A]])
         extends StreamRendererBackend[F, A](stream) {
 
       val hold: Hold[F, Pot[A]] =
@@ -39,24 +41,31 @@ object StreamRendererMod {
 
       override protected val directSetState: Pot[A] => F[Unit] = $.setStateIn[F]
 
-      override protected lazy val streamSetState: Pot[A] => F[Unit] = hold.set
+      override protected lazy val streamSetState: Pot[A] => F[Unit] =
+        pot =>
+          hold.set(pot) >> hold.enable // This will debounce messages for at least the hold time.
 
       def render(
-        props: Props[F, A],
+        props: Props[A],
         state: Pot[A]
       ): VdomNode =
         props(
           state.map(a =>
-            ViewF[F, A](
+            ViewF[SyncIO, A](
               a,
-              f => hold.enable.flatMap(_ => $.modStateIn[F](_.map(f)))
+              (f: A => A, cb: A => SyncIO[Unit]) =>
+                hold.enable.runAsync.flatMap(_ =>
+                  // I'm not very happy about the cast.
+                  // However, this is only executed when the pot is ready, so the cast should be safe.
+                  $.modStateInSyncIO(_.map(f), pot => cb(pot.asInstanceOf[Ready[A]].value))
+                )
             )
           )
         )
     }
 
     ScalaComponent
-      .builder[Props[F, A]]
+      .builder[Props[A]]
       .initialState(Pot.pending[A])
       .renderBackend[Backend]
       .componentDidMount(_.backend.startUpdates)

--- a/js/src/main/scala/crystal/react/reuse/AppliedSyntax.scala
+++ b/js/src/main/scala/crystal/react/reuse/AppliedSyntax.scala
@@ -133,4 +133,73 @@ protected trait AppliedSyntax {
     ): Reuse[B] =
       Reuse.by((r, s, t, u))(ev(aa.value())(r, s, t, u))
   }
+
+  implicit class AppliedFn5Ops[A, R, S, T, U, V, B](aa: Applied[A])(implicit
+    ev:                                                 A =:= ((R, S, T, U, V) => B)
+  ) {
+    /*
+     * Given a (R, S, T, U, V) => B , instantiate R and build a (S, T, U, V) ==> B.
+     */
+    def apply(
+      r:         R
+    )(implicit
+      classTagR: ClassTag[R],
+      reuseR:    Reusability[R]
+    ): Reuse[(S, T, U, V) => B] =
+      Reuse.by(r)((s, t, u, v) => ev(aa.value())(r, s, t, u, v))
+
+    /*
+     * Given a (R, S, T, U, V) => B , instantiate R and S and build a (T, U, V) ==> B.
+     */
+    def apply(
+      r:          R,
+      s:          S
+    )(implicit
+      classTagRS: ClassTag[(R, S)],
+      reuseR:     Reusability[(R, S)]
+    ): Reuse[(T, U, V) => B] =
+      Reuse.by((r, s))((t, u, v) => ev(aa.value())(r, s, t, u, v))
+
+    /*
+     * Given a (R, S, T, U, V) => B , instantiate R, S and T and build a (U, V) ==> B.
+     */
+    def apply(
+      r:          R,
+      s:          S,
+      t:          T
+    )(implicit
+      classTagRS: ClassTag[(R, S, T)],
+      reuseR:     Reusability[(R, S, T)]
+    ): Reuse[(U, V) => B] =
+      Reuse.by((r, s, t))((u, v) => ev(aa.value())(r, s, t, u, v))
+
+    /*
+     * Given a (R, S, T, U, V) => B , instantiate R, S, T and U and build a V ==> B Reuse[B].
+     */
+    def apply(
+      r:          R,
+      s:          S,
+      t:          T,
+      u:          U
+    )(implicit
+      classTagRS: ClassTag[(R, S, T, U)],
+      reuseR:     Reusability[(R, S, T, U)]
+    ): Reuse[V => B] =
+      Reuse.by((r, s, t, u))(v => ev(aa.value())(r, s, t, u, v))
+
+    /*
+     * Given a (R, S, T, U, V) => B , instantiate R, S, T, U and V and build a Reuse[B].
+     */
+    def apply(
+      r:          R,
+      s:          S,
+      t:          T,
+      u:          U,
+      v:          V
+    )(implicit
+      classTagRS: ClassTag[(R, S, T, U, V)],
+      reuseR:     Reusability[(R, S, T, U, V)]
+    ): Reuse[B] =
+      Reuse.by((r, s, t, u, v))(ev(aa.value())(r, s, t, u, v))
+  }
 }

--- a/js/src/main/scala/crystal/react/reuse/package.scala
+++ b/js/src/main/scala/crystal/react/reuse/package.scala
@@ -6,7 +6,7 @@ import scala.reflect.ClassTag
 package object reuse {
   type ==>[A, B] = Reuse[A => B]
 
-  implicit class AnyReuseOps[A](val a: A) extends AnyVal {
+  implicit class AnyReuseOps[A](private val a: A) extends AnyVal {
     def reuseAlways: Reuse[A] = Reuse.always(a)
 
     def reuseNever: Reuse[A] = Reuse.never(a)
@@ -21,7 +21,7 @@ package object reuse {
     def curryReusing: Reuse.Curried1[A] = Reuse.currying(a)
   }
 
-  implicit class Tuple2ReuseOps[R, S](val t: (R, S)) extends AnyVal {
+  implicit class Tuple2ReuseOps[R, S](private val t: (R, S)) extends AnyVal {
     /*
      * Implements the idiom:
      *   `(a, b).curryReusing( (A, B, C) => D )`
@@ -32,7 +32,7 @@ package object reuse {
     def curryReusing: Reuse.Curried2[R, S] = Reuse.currying(t._1, t._2)
   }
 
-  implicit class Tuple3ReuseOps[R, S, T](val t: (R, S, T)) extends AnyVal {
+  implicit class Tuple3ReuseOps[R, S, T](private val t: (R, S, T)) extends AnyVal {
     /*
      * Implements the idiom:
      *   `(a, b, c).curryReusing( (A, B, C, D) => E )`
@@ -43,7 +43,7 @@ package object reuse {
     def curryReusing: Reuse.Curried3[R, S, T] = Reuse.currying(t._1, t._2, t._3)
   }
 
-  implicit class Fn1ReuseOps[R, B](val fn: R => B) extends AnyVal {
+  implicit class Fn1ReuseOps[R, B](private val fn: R => B) extends AnyVal {
     /*
      * Implements the idiom:
      *   `(R => B).reuseCurrying(r)`
@@ -57,7 +57,7 @@ package object reuse {
     ): Reuse[B] = Reuse.currying(r).in(fn)
   }
 
-  implicit class Fn2ReuseOps[R, S, B](val fn: (R, S) => B) extends AnyVal {
+  implicit class Fn2ReuseOps[R, S, B](private val fn: (R, S) => B) extends AnyVal {
     /*
      * Implements the idiom:
      *   `((R, S) => B).reuseCurrying(r)`
@@ -84,7 +84,7 @@ package object reuse {
     ): Reuse[B] = Reuse.currying(r, s).in(fn)
   }
 
-  implicit class Fn3ReuseOps[R, S, T, B](val fn: (R, S, T) => B) extends AnyVal {
+  implicit class Fn3ReuseOps[R, S, T, B](private val fn: (R, S, T) => B) extends AnyVal {
     /*
      * Implements the idiom:
      *   `((R, S, T) => B).reuseCurrying(r)`

--- a/jvm/src/main/scala/crystal/ComponentTypesForPlatform.scala
+++ b/jvm/src/main/scala/crystal/ComponentTypesForPlatform.scala
@@ -1,6 +1,6 @@
 package crystal
 
 trait ComponentTypesForPlatform extends ComponentTypes {
-  type StreamRenderer[A]          = Nothing
-  type StreamRendererMod[F[_], A] = Nothing
+  type StreamRenderer[A]    = Nothing
+  type StreamRendererMod[A] = Nothing
 }

--- a/shared/src/main/scala/crystal/package.scala
+++ b/shared/src/main/scala/crystal/package.scala
@@ -2,8 +2,8 @@ import cats.Monad
 import cats.syntax.all._
 
 package object crystal {
-  type StreamRenderer[A]          = ComponentTypes.StreamRenderer[A]
-  type StreamRendererMod[F[_], A] = ComponentTypes.StreamRendererMod[F, A]
+  type StreamRenderer[A]    = ComponentTypes.StreamRenderer[A]
+  type StreamRendererMod[A] = ComponentTypes.StreamRendererMod[A]
 
   implicit class UnitMonadOps[F[_]: Monad](f: F[Unit]) {
     def when(cond: F[Boolean]): F[Unit] =
@@ -14,7 +14,7 @@ package object crystal {
 package crystal {
   trait ComponentTypes {
     type StreamRenderer[A]
-    type StreamRendererMod[F[_], A]
+    type StreamRendererMod[A]
   }
 
   object ComponentTypes extends ComponentTypesForPlatform

--- a/shared/src/main/scala/crystal/viewF.scala
+++ b/shared/src/main/scala/crystal/viewF.scala
@@ -2,33 +2,34 @@ package crystal
 
 import cats.syntax.all._
 import cats.Id
+import cats.Monad
 import cats.effect._
 import monocle.Iso
 import monocle.Lens
 import monocle.Optional
 import monocle.Prism
 import monocle.Traversal
-import cats.FlatMap
 
-sealed trait ViewOps[F[_], G[_], A] {
+sealed abstract class ViewOps[F[_]: Monad, G[_], A] {
   val get: G[A]
 
-  val set: A => F[Unit]
+  val setCB: (A, G[A] => F[Unit]) => F[Unit] = (a, cb) => modCB(_ => a, cb)
 
-  val mod: (A => A) => F[Unit]
+  val set: A => F[Unit] = a => mod(_ => a)
 
-  val modAndGet: (A => A) => F[G[A]]
+  val modCB: ((A => A), G[A] => F[Unit]) => F[Unit]
+
+  val mod: (A => A) => F[Unit] = f => modCB(f, _ => Monad[F].unit)
+
+  def modAndGet(f: A => A)(implicit F: Async[F]): F[G[A]]
 }
 
 // The difference between a View and a StateSnapshot is that the modifier doesn't act on the current value,
 // but passes the modifier function to an external source of truth. Since we are defining no getter
 // from such source of truth, a View is defined in terms of a modifier function instead of a setter.
-final class ViewF[F[_]: Async, A](val get: A, val mod: (A => A) => F[Unit])
-    extends ViewOps[F, Id, A] {
-
-  val set: A => F[Unit] = a => mod(_ => a)
-
-  def modAndExtract[B]: (A => (A, B)) => F[B] = f =>
+final class ViewF[F[_]: Monad, A](val get: A, val modCB: ((A => A), A => F[Unit]) => F[Unit])
+    extends ViewOps[F, Id, A] { self =>
+  def modAndExtract[B](f: (A => (A, B)))(implicit F: Async[F]): F[B] =
     Async[F].async { cb =>
       mod { a: A =>
         val (fa, b) = f(a)
@@ -40,31 +41,34 @@ final class ViewF[F[_]: Async, A](val get: A, val mod: (A => A) => F[Unit])
 
   // In a ViewF, we can derive modAndGet. In ViewOptF and ViewListF we have to pass it, since their
   // mod functions have no idea of the enclosing structure.
-  val modAndGet: (A => A) => F[A] = f => modAndExtract(f.andThen(a => (a, a)))
+  def modAndGet(f: A => A)(implicit F: Async[F]): F[A] =
+    modAndExtract(f.andThen(a => (a, a)))
 
   def zoom[B](getB: A => B)(modB: (B => B) => A => A): ViewF[F, B] =
     new ViewF(
       getB(get),
-      (f: B => B) => mod(modB(f))
+      (f: B => B, cb: B => F[Unit]) => modCB(modB(f), cb.compose(getB))
     )
 
   def zoomOpt[B](
     getB: A => Option[B]
   )(modB: (B => B) => A => A): ViewOptF[F, B] =
-    new ViewOptF(
-      getB(get),
-      (f: B => B) => mod(modB(f)),
-      (f: B => B) => modAndGet(modB(f)).map(getB)
-    )
+    new ViewOptF(getB(get),
+                 (f: B => B, cb: Option[B] => F[Unit]) => modCB(modB(f), cb.compose(getB))
+    ) {
+      def modAndGet(f: B => B)(implicit F: Async[F]): F[Option[B]] =
+        self.modAndGet(modB(f)).map(getB)
+    }
 
   def zoomList[B](
     getB: A => List[B]
   )(modB: (B => B) => A => A): ViewListF[F, B] =
-    new ViewListF(
-      getB(get),
-      (f: B => B) => mod(modB(f)),
-      (f: B => B) => modAndGet(modB(f)).map(getB)
-    )
+    new ViewListF(getB(get),
+                  (f: B => B, cb: List[B] => F[Unit]) => modCB(modB(f), cb.compose(getB))
+    ) {
+      def modAndGet(f: B => B)(implicit F: Async[F]): F[List[B]] =
+        self.modAndGet(modB(f)).map(getB)
+    }
 
   def as[B](iso: Iso[A, B]): ViewF[F, B] = zoom(iso.asLens)
 
@@ -75,39 +79,33 @@ final class ViewF[F[_]: Async, A](val get: A, val mod: (A => A) => F[Unit])
   def zoom[B](lens: Lens[A, B]): ViewF[F, B] =
     zoom(lens.get _)(lens.modify)
 
-  def zoom[B](
-    optional: Optional[A, B]
-  ): ViewOptF[F, B] =
+  def zoom[B](optional: Optional[A, B]): ViewOptF[F, B] =
     zoomOpt(optional.getOption _)(optional.modify)
 
   def zoom[B](prism: Prism[A, B]): ViewOptF[F, B] =
     zoomOpt(prism.getOption _)(prism.modify)
 
-  def zoom[B](
-    traversal: Traversal[A, B]
-  ): ViewListF[F, B] =
+  def zoom[B](traversal: Traversal[A, B]): ViewListF[F, B] =
     zoomList(traversal.getAll _)(traversal.modify)
 
-  def withOnMod(
-    f: A => F[Unit]
-  ): ViewF[F, A] =
-    new ViewF[F, A](get, modF => modAndGet(modF).flatMap(f))
+  def withOnMod(f: A => F[Unit]): ViewF[F, A] =
+    new ViewF[F, A](
+      get,
+      (modF, cb) => modCB(modF, a => f(a) >> cb(a))
+    )
 
   override def toString(): String = s"ViewF($get, <modFn>)"
 }
 
 object ViewF {
-  def apply[F[_]: Async, A](value: A, mod: (A => A) => F[Unit]): ViewF[F, A] =
-    new ViewF(value, mod)
+  def apply[F[_]: Monad, A](value: A, modCB: ((A => A), A => F[Unit]) => F[Unit]): ViewF[F, A] =
+    new ViewF(value, modCB)
 }
 
-final class ViewOptF[F[_]: FlatMap, A](
-  val get:       Option[A],
-  val mod:       (A => A) => F[Unit],
-  val modAndGet: (A => A) => F[Option[A]]
-) extends ViewOps[F, Option, A] {
-  val set: A => F[Unit] = a => mod(_ => a)
-
+abstract class ViewOptF[F[_]: Monad, A](
+  val get:   Option[A],
+  val modCB: ((A => A), Option[A] => F[Unit]) => F[Unit]
+) extends ViewOps[F, Option, A] { self =>
   def as[B](iso: Iso[A, B]): ViewOptF[F, B] = zoom(iso.asLens)
 
   def asList: ViewListF[F, A] = zoom(Iso.id[A].asTraversal)
@@ -115,27 +113,33 @@ final class ViewOptF[F[_]: FlatMap, A](
   def zoom[B](getB: A => B)(modB: (B => B) => A => A): ViewOptF[F, B] =
     new ViewOptF(
       get.map(getB),
-      (f: B => B) => mod(modB(f)),
-      (f: B => B) => modAndGet(modB(f)).map(_.map(getB))
-    )
+      (f: B => B, cb: Option[B] => F[Unit]) => modCB(modB(f), cb.compose(_.map(getB)))
+    ) {
+      def modAndGet(f: B => B)(implicit F: Async[F]): F[Option[B]] =
+        self.modAndGet(modB(f)).map(_.map(getB))
+    }
 
   def zoomOpt[B](
     getB: A => Option[B]
   )(modB: (B => B) => A => A): ViewOptF[F, B] =
-    new ViewOptF(
-      get.flatMap(getB),
-      (f: B => B) => mod(modB(f)),
-      (f: B => B) => modAndGet(modB(f)).map(_.flatMap(getB))
-    )
+    new ViewOptF(get.flatMap(getB),
+                 (f: B => B, cb: Option[B] => F[Unit]) =>
+                   modCB(modB(f), cb.compose(_.flatMap(getB)))
+    ) {
+      def modAndGet(f: B => B)(implicit F: Async[F]): F[Option[B]] =
+        self.modAndGet(modB(f)).map(_.flatMap(getB))
+    }
 
   def zoomList[B](
     getB: A => List[B]
   )(modB: (B => B) => A => A): ViewListF[F, B] =
-    new ViewListF(
-      get.map(getB).orEmpty,
-      (f: B => B) => mod(modB(f)),
-      (f: B => B) => modAndGet(modB(f)).map(_.map(getB).orEmpty)
-    )
+    new ViewListF(get.map(getB).orEmpty,
+                  (f: B => B, cb: List[B] => F[Unit]) =>
+                    modCB(modB(f), cb.compose(_.toList.flatMap(getB)))
+    ) {
+      def modAndGet(f: B => B)(implicit F: Async[F]): F[List[B]] =
+        self.modAndGet(modB(f)).map(_.map(getB).orEmpty)
+    }
 
   def zoom[B](lens: Lens[A, B]): ViewOptF[F, B] =
     zoom(lens.get _)(lens.modify)
@@ -151,47 +155,52 @@ final class ViewOptF[F[_]: FlatMap, A](
   ): ViewListF[F, B] =
     zoomList(traversal.getAll)(traversal.modify)
 
-  def withOnMod(
-    f: Option[A] => F[Unit]
-  ): ViewOptF[F, A] =
-    new ViewOptF[F, A](get, modF => modAndGet(modF).flatMap(f), modAndGet)
+  def withOnMod(f: Option[A] => F[Unit]): ViewOptF[F, A] =
+    new ViewOptF[F, A](
+      get,
+      (modF, cb) => modCB(modF, a => f(a) >> cb(a))
+    ) {
+      def modAndGet(f: A => A)(implicit F: Async[F]): F[Option[A]] =
+        self.modAndGet(f)
+    }
 
   override def toString(): String = s"ViewOptF($get, <modFn>)"
 }
 
-final class ViewListF[F[_]: FlatMap, A](
-  val get:       List[A],
-  val mod:       (A => A) => F[Unit],
-  val modAndGet: (A => A) => F[List[A]]
-) extends ViewOps[F, List, A] {
-  val set: A => F[Unit] = a => mod(_ => a)
-
+abstract class ViewListF[F[_]: Monad, A](
+  val get:   List[A],
+  val modCB: ((A => A), List[A] => F[Unit]) => F[Unit]
+) extends ViewOps[F, List, A] { self =>
   def as[B](iso: Iso[A, B]): ViewListF[F, B] = zoom(iso.asLens)
 
   def zoom[B](getB: A => B)(modB: (B => B) => A => A): ViewListF[F, B] =
-    new ViewListF(
-      get.map(getB),
-      (f: B => B) => mod(modB(f)),
-      (f: B => B) => modAndGet(modB(f)).map(_.map(getB))
-    )
+    new ViewListF(get.map(getB),
+                  (f: B => B, cb: List[B] => F[Unit]) => modCB(modB(f), cb.compose(_.map(getB)))
+    ) {
+      def modAndGet(f: B => B)(implicit F: Async[F]): F[List[B]] =
+        self.modAndGet(modB(f)).map(_.map(getB))
+    }
 
   def zoomOpt[B](
     getB: A => Option[B]
   )(modB: (B => B) => A => A): ViewListF[F, B] =
-    new ViewListF(
-      get.flatMap(getB),
-      (f: B => B) => mod(modB(f)),
-      (f: B => B) => modAndGet(modB(f)).map(_.flatMap(getB))
-    )
+    new ViewListF(get.flatMap(getB),
+                  (f: B => B, cb: List[B] => F[Unit]) => modCB(modB(f), cb.compose(_.flatMap(getB)))
+    ) {
+      def modAndGet(f: B => B)(implicit F: Async[F]): F[List[B]] =
+        self.modAndGet(modB(f)).map(_.flatMap(getB))
+    }
 
   def zoomList[B](
     getB: A => List[B]
   )(modB: (B => B) => A => A): ViewListF[F, B] =
     new ViewListF(
       get.flatMap(getB),
-      (f: B => B) => mod(modB(f)),
-      (f: B => B) => modAndGet(modB(f)).map(_.flatMap(getB))
-    )
+      (f: B => B, cb: List[B] => F[Unit]) => modCB(modB(f), cb.compose(_.flatMap(getB)))
+    ) {
+      def modAndGet(f: B => B)(implicit F: Async[F]): F[List[B]] =
+        self.modAndGet(modB(f)).map(_.flatMap(getB))
+    }
 
   def zoom[B](lens: Lens[A, B]): ViewListF[F, B] =
     zoom(lens.get _)(lens.modify)
@@ -207,10 +216,14 @@ final class ViewListF[F[_]: FlatMap, A](
   ): ViewListF[F, B] =
     zoomList(traversal.getAll)(traversal.modify)
 
-  def withOnMod(
-    f: List[A] => F[Unit]
-  ): ViewListF[F, A] =
-    new ViewListF[F, A](get, modF => modAndGet(modF).flatMap(f), modAndGet)
+  def withOnMod(f: List[A] => F[Unit]): ViewListF[F, A] =
+    new ViewListF[F, A](
+      get,
+      (modF, cb) => modCB(modF, a => f(a) >> cb(a))
+    ) {
+      def modAndGet(f: A => A)(implicit F: Async[F]): F[List[A]] =
+        self.modAndGet(f)
+    }
 
   override def toString(): String = s"ViewListF($get, <modFn>)"
 }

--- a/shared/src/test/scala/crystal/ViewFSpec.scala
+++ b/shared/src/test/scala/crystal/ViewFSpec.scala
@@ -11,7 +11,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Int].mod") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update)
+      view = ViewF(value, modCB(ref))
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === 1))
@@ -20,7 +20,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Int].set") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update)
+      view = ViewF(value, modCB(ref))
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === 1))
@@ -29,7 +29,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Int].modAndGet") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update)
+      view = ViewF(value, modCB(ref))
       get <- view.modAndGet(_ + 1)
     } yield assert(get === 1))
   }
@@ -38,7 +38,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
     (for {
       ref      <- Ref[IO].of(value)
       d        <- Deferred[IO, Int]
-      view      = ViewF(value, ref.update).withOnMod(a => d.complete(a * 2).void)
+      view      = ViewF(value, modCB(ref)).withOnMod(a => d.complete(a * 2).void)
       _        <- view.mod(_ + 1)
       get      <- ref.get
       captured <- d.get
@@ -54,7 +54,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].zoom(Lens).mod") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).zoom(lens)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -63,7 +63,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].zoom(Lens).set") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).zoom(lens)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -72,7 +72,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].zoom(Lens).modAndGet") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).zoom(lens)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === 1))
   }
@@ -80,7 +80,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].as(Wrap.iso).mod") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).as(Wrap.iso)
+      view = ViewF(wrappedValue, modCB(ref)).as(Wrap.iso)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -89,7 +89,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].as(Wrap.iso).set") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).as(Wrap.iso)
+      view = ViewF(wrappedValue, modCB(ref)).as(Wrap.iso)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -98,7 +98,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].as(Wrap.iso).modAndGet") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).as(Wrap.iso)
+      view = ViewF(wrappedValue, modCB(ref)).as(Wrap.iso)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === 1))
   }
@@ -106,7 +106,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asOpt.zoom(Lens).mod") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).asOpt.zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).asOpt.zoom(lens)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -115,7 +115,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asOpt.zoom(Lens).set") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).asOpt.zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).asOpt.zoom(lens)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -124,7 +124,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asOpt.zoom(Lens).modAndGet") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).asOpt.zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).asOpt.zoom(lens)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === 1.some))
   }
@@ -132,7 +132,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asList.zoom(Lens).mod") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).asList.zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).asList.zoom(lens)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -141,7 +141,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asList.zoom(Lens).set") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).asList.zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).asList.zoom(lens)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -150,7 +150,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asList.zoom(Lens).modAndGet") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, ref.update).asList.zoom(lens)
+      view = ViewF(wrappedValue, modCB(ref)).asList.zoom(lens)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === List(1)))
   }

--- a/shared/src/test/scala/crystal/ViewListFSpec.scala
+++ b/shared/src/test/scala/crystal/ViewListFSpec.scala
@@ -13,7 +13,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[WrapList[Int]].zoom(Traversal).mod") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update).zoom(traversal)
+      view = ViewF(value, modCB(ref)).zoom(traversal)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === WrapList(List(1, 2, 3))))
@@ -22,7 +22,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[WrapList[Int]].zoom(Traversal).set") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update).zoom(traversal)
+      view = ViewF(value, modCB(ref)).zoom(traversal)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === WrapList(List(1, 1, 1))))
@@ -31,7 +31,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[WrapList[Int]].zoom(Traversal).modAndGet") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update).zoom(traversal)
+      view = ViewF(value, modCB(ref)).zoom(traversal)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === List(1, 2, 3)))
   }
@@ -40,7 +40,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
     (for {
       ref      <- Ref[IO].of(value)
       d        <- Deferred[IO, List[Int]]
-      view      = ViewF(value, ref.update).zoom(traversal).withOnMod(a => d.complete(a.map(_ * 2)).void)
+      view      = ViewF(value, modCB(ref)).zoom(traversal).withOnMod(a => d.complete(a.map(_ * 2)).void)
       _        <- view.mod(_ + 1)
       get      <- ref.get
       captured <- d.get
@@ -55,7 +55,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[List[Wrap[Int]]].zoom(Traversal).as(Wrap.iso).mod") {
     (for {
       ref <- Ref[IO].of(valueList)
-      view = ViewF(valueList, ref.update).zoom(Traversal.fromTraverse[List, Wrap[Int]]).as(Wrap.iso)
+      view = ViewF(valueList, modCB(ref)).zoom(Traversal.fromTraverse[List, Wrap[Int]]).as(Wrap.iso)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === List(Wrap(1))))
@@ -64,7 +64,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(Traversal).as(Wrap.iso).set") {
     (for {
       ref <- Ref[IO].of(valueList)
-      view = ViewF(valueList, ref.update).zoom(Traversal.fromTraverse[List, Wrap[Int]]).as(Wrap.iso)
+      view = ViewF(valueList, modCB(ref)).zoom(Traversal.fromTraverse[List, Wrap[Int]]).as(Wrap.iso)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === List(Wrap(1))))
@@ -73,7 +73,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(Traversal).as(Wrap.iso).modAndGet") {
     (for {
       ref <- Ref[IO].of(valueList)
-      view = ViewF(valueList, ref.update).zoom(Traversal.fromTraverse[List, Wrap[Int]]).as(Wrap.iso)
+      view = ViewF(valueList, modCB(ref)).zoom(Traversal.fromTraverse[List, Wrap[Int]]).as(Wrap.iso)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === List(1)))
   }
@@ -88,7 +88,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[WrapOpt[WrapList[Int]]]].zoom(Traversal).mod") {
     (for {
       ref <- Ref[IO].of(complexValue1)
-      view = ViewF(complexValue1, ref.update).zoom(complexTraversal1)
+      view = ViewF(complexValue1, modCB(ref)).zoom(complexTraversal1)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === Wrap(WrapOpt(WrapList(List(1, 2, 3)).some))))
@@ -97,7 +97,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[WrapOpt[WrapList[Int]]]].zoom(Traversal).set") {
     (for {
       ref <- Ref[IO].of(complexValue1)
-      view = ViewF(complexValue1, ref.update).zoom(complexTraversal1)
+      view = ViewF(complexValue1, modCB(ref)).zoom(complexTraversal1)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === Wrap(WrapOpt(WrapList(List(1, 1, 1)).some))))
@@ -106,7 +106,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[WrapOpt[WrapList[Int]]]].zoom(Traversal).modAndGet") {
     (for {
       ref <- Ref[IO].of(complexValue1)
-      view = ViewF(complexValue1, ref.update).zoom(complexTraversal1)
+      view = ViewF(complexValue1, modCB(ref)).zoom(complexTraversal1)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === List(1, 2, 3)))
   }
@@ -130,7 +130,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[WrapList[WrapOpt[Int]]]].zoom(Traversal).mod") {
     (for {
       ref <- Ref[IO].of(complexValue2)
-      view = ViewF(complexValue2, ref.update).zoom(complexTraversal2)
+      view = ViewF(complexValue2, modCB(ref)).zoom(complexTraversal2)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(
@@ -150,7 +150,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[WrapList[WrapOpt[Int]]]].zoom(Traversal).set") {
     (for {
       ref <- Ref[IO].of(complexValue2)
-      view = ViewF(complexValue2, ref.update).zoom(complexTraversal2)
+      view = ViewF(complexValue2, modCB(ref)).zoom(complexTraversal2)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(
@@ -170,7 +170,7 @@ class ViewListFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[WrapList[WrapOpt[Int]]]].zoom(Traversal).modAndGet") {
     (for {
       ref <- Ref[IO].of(complexValue2)
-      view = ViewF(complexValue2, ref.update).zoom(complexTraversal2)
+      view = ViewF(complexValue2, modCB(ref)).zoom(complexTraversal2)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === List(1, 2, 3)))
   }

--- a/shared/src/test/scala/crystal/ViewOptFSpec.scala
+++ b/shared/src/test/scala/crystal/ViewOptFSpec.scala
@@ -13,7 +13,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[WrapOpt[Int]].zoom(Optional).mod") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update).zoom(optional)
+      view = ViewF(value, modCB(ref)).zoom(optional)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === WrapOpt(1.some)))
@@ -22,7 +22,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[WrapOpt[Int]].zoom(Optional).set") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update).zoom(optional)
+      view = ViewF(value, modCB(ref)).zoom(optional)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === WrapOpt(1.some)))
@@ -31,7 +31,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[WrapOpt[Int]].zoom(Optional).modAndGet") {
     (for {
       ref <- Ref[IO].of(value)
-      view = ViewF(value, ref.update).zoom(optional)
+      view = ViewF(value, modCB(ref)).zoom(optional)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === 1.some))
   }
@@ -40,7 +40,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
     (for {
       ref      <- Ref[IO].of(value)
       d        <- Deferred[IO, Option[Int]]
-      view      = ViewF(value, ref.update).zoom(optional).withOnMod(a => d.complete(a.map(_ * 2)).void)
+      view      = ViewF(value, modCB(ref)).zoom(optional).withOnMod(a => d.complete(a.map(_ * 2)).void)
       _        <- view.mod(_ + 1)
       get      <- ref.get
       captured <- d.get
@@ -55,7 +55,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).as(Wrap.iso).mod") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, ref.update).zoom(some[Wrap[Int]]).as(Wrap.iso)
+      view = ViewF(valueOpt, modCB(ref)).zoom(some[Wrap[Int]]).as(Wrap.iso)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === Wrap(1).some))
@@ -64,7 +64,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).as(Wrap.iso).set") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, ref.update).zoom(some[Wrap[Int]]).as(Wrap.iso)
+      view = ViewF(valueOpt, modCB(ref)).zoom(some[Wrap[Int]]).as(Wrap.iso)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === Wrap(1).some))
@@ -73,7 +73,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).as(Wrap.iso).modAndGet") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, ref.update).zoom(some[Wrap[Int]]).as(Wrap.iso)
+      view = ViewF(valueOpt, modCB(ref)).zoom(some[Wrap[Int]]).as(Wrap.iso)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === 1.some))
   }
@@ -81,7 +81,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).asList.mod") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, ref.update).zoom(some[Wrap[Int]]).asList
+      view = ViewF(valueOpt, modCB(ref)).zoom(some[Wrap[Int]]).asList
       _   <- view.mod(_.map(_ + 1))
       get <- ref.get
     } yield assert(get === Wrap(1).some))
@@ -90,7 +90,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).asList.set") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, ref.update).zoom(some[Wrap[Int]]).asList
+      view = ViewF(valueOpt, modCB(ref)).zoom(some[Wrap[Int]]).asList
       _   <- view.set(Wrap(1))
       get <- ref.get
     } yield assert(get === Wrap(1).some))
@@ -99,7 +99,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).asList.modAndGet") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, ref.update).zoom(some[Wrap[Int]]).asList
+      view = ViewF(valueOpt, modCB(ref)).zoom(some[Wrap[Int]]).asList
       get <- view.modAndGet(_.map(_ + 1))
     } yield assert(get === List(Wrap(1))))
   }

--- a/shared/src/test/scala/crystal/package.scala
+++ b/shared/src/test/scala/crystal/package.scala
@@ -1,9 +1,17 @@
-import cats.kernel.Eq
+import cats.Eq
+import cats.FlatMap
+import cats.syntax.all._
+import cats.effect.Ref
 import monocle.macros.Lenses
 import monocle.Optional
 import monocle.Traversal
 import monocle.function.Possible.possible
 import monocle.Iso
+
+package object crystal {
+  def modCB[F[_]: FlatMap, A](ref: Ref[F, A]): ((A => A), A => F[Unit]) => F[Unit] =
+    (f, cb) => ref.modify(f >>> (a => (a, a))) >>= cb
+}
 
 package crystal {
   @Lenses


### PR DESCRIPTION
Using sync callbacks has advantages in react (as opposed to triggering async ones).

Therefore, the current PR changes the approach of `View` (and the `StreamRenderer`s that use it) to switch to a sync callback approach. For the moment, the chosen sync effect is `SyncIO`, but we everything should work just fine with `CallbackTo`. We can abstract the sync effect away, but let's wait for `scalajs-react`'s generalized effects, which will make it easier.

Also, we now use `Reuse` in parameters that don't have reusability, and the `Context` components now return proper components.