### PR TITLE
Remove SyncIO. Embrace DefaultEffect.

### DIFF
--- a/js/src/main/scala/crystal/react/ContextProvider.scala
+++ b/js/src/main/scala/crystal/react/ContextProvider.scala
@@ -4,17 +4,21 @@ import crystal.ViewF
 import implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import cats.effect.SyncIO
 import crystal.react.reuse.Reuse
+import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
+import cats.Monad
 
-object ContextProviderSyncIO {
+object ContextProvider {
 
-  class Backend[C](ctx: Ctx[SyncIO, C])($ : BackendScope[Reuse[VdomNode], C]) {
+  class Backend[C](ctx: Ctx[DefaultS, C])($ : BackendScope[Reuse[VdomNode], C])(implicit
+    DefaultS:           Monad[DefaultS]
+  ) {
     def render(props: Reuse[VdomNode]) =
-      ctx.provide(ViewF.fromStateSyncIO($))(props)
+      ctx.provide(ViewF.fromState($))(props)
   }
 
-  def apply[C](ctx: Ctx[SyncIO, C], initCtx: C)(implicit
+  def apply[C](ctx: Ctx[DefaultS, C], initCtx: C)(implicit
+    DefaultS:       Monad[DefaultS],
     reusabilityC:   Reusability[C]
   ): ContextComponent[C, Backend[C]] =
     ScalaComponent

--- a/js/src/main/scala/crystal/react/Hold.scala
+++ b/js/src/main/scala/crystal/react/Hold.scala
@@ -1,11 +1,12 @@
 package crystal.react
 
 import crystal.implicits._
-import cats.effect._
+import cats.effect.{ Async, Sync }
 import cats.syntax.all._
 import cats.effect.implicits._
 import scala.concurrent.duration.FiniteDuration
 import cats.effect.{ Ref, Temporal }
+import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 
 /** Encapsulates an effectful `setter`. When `enable` is called, calls to `setter` will be delayed
   * for `duration`. Each call to `enable` resets the internal timer, i.e: `duration` is guaranteed
@@ -39,11 +40,11 @@ class Hold[F[_]: Async, A](
 
 object Hold {
   def apply[F[_]: Async, A](
-    setter:   A => F[Unit],
-    duration: Option[FiniteDuration]
-  ): SyncIO[Hold[F, A]] =
+    setter:            A => F[Unit],
+    duration:          Option[FiniteDuration]
+  )(implicit DefaultS: Sync[DefaultS]): DefaultS[Hold[F, A]] =
     for {
-      cancelToken <- Ref.in[SyncIO, F, Option[F[Unit]]](none)
-      buffer      <- Ref.in[SyncIO, F, Option[A]](none)
+      cancelToken <- Ref.in[DefaultS, F, Option[F[Unit]]](none)
+      buffer      <- Ref.in[DefaultS, F, Option[A]](none)
     } yield new Hold(setter, duration, cancelToken, buffer)
 }

--- a/js/src/main/scala/crystal/react/StateProvider.scala
+++ b/js/src/main/scala/crystal/react/StateProvider.scala
@@ -4,19 +4,25 @@ import crystal.ViewF
 import implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import cats.effect.SyncIO
+import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import crystal.react.reuse.Reuse
+import cats.Monad
 
-object StateProviderSyncIO {
+object StateProvider {
 
-  class Backend[M]($ : BackendScope[Reuse[ViewF[SyncIO, M] => VdomNode], M]) {
-    def render(props: Reuse[ViewF[SyncIO, M] => VdomNode]) =
-      props(ViewF.fromStateSyncIO($))
+  class Backend[M]($ : BackendScope[Reuse[ViewF[DefaultS, M] => VdomNode], M])(implicit
+    DefaultS:          Monad[DefaultS]
+  ) {
+    def render(props: Reuse[ViewF[DefaultS, M] => VdomNode]) =
+      props(ViewF.fromState($))
   }
 
-  def apply[M](model: M)(implicit reusabilityM: Reusability[M]): StateComponent[M, Backend[M]] =
+  def apply[M](model: M)(implicit
+    DefaultS:         Monad[DefaultS],
+    reusabilityM:     Reusability[M]
+  ): StateComponent[M, Backend[M]] =
     ScalaComponent
-      .builder[Reuse[ViewF[SyncIO, M] => VdomNode]]
+      .builder[Reuse[ViewF[DefaultS, M] => VdomNode]]
       .initialState(model)
       .backend($ => new Backend($))
       .renderBackend

--- a/js/src/main/scala/crystal/react/StreamRendererBackend.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererBackend.scala
@@ -29,8 +29,8 @@ abstract class StreamRendererBackend[F[_]: Async: Dispatcher: Logger, A](stream:
       }
       .start
       .map(fiber => cancelToken = fiber.cancel.some)
-      .runAsyncCB
+      .runAsync
 
   def stopUpdates: Callback =
-    cancelToken.map(_.runAsyncCB).getOrEmpty
+    cancelToken.map(_.runAsync).getOrEmpty
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -22,10 +22,9 @@ object Settings {
 
     val ReactScalaJS = Def.setting(
       Seq(
-        "com.github.japgolly.scalajs-react" %%% "core"               % scalajsReact,
+        "com.github.japgolly.scalajs-react" %%% "core-bundle-cb_io"  % scalajsReact,
         "com.github.japgolly.scalajs-react" %%% "extra"              % scalajsReact,
-        "com.github.japgolly.scalajs-react" %%% "extra-ext-monocle3" % scalajsReact,
-        "com.github.japgolly.scalajs-react" %%% "core-ext-cats"      % scalajsReact
+        "com.github.japgolly.scalajs-react" %%% "extra-ext-monocle3" % scalajsReact
       )
     )
 


### PR DESCRIPTION
`scalajs-react` now has a bundle that provides support for `CallbackTo` as sync effect and `IO` as async.

We are adopting this bundle, so this PR does away with using `SyncIO`. New code uses `DefaultEffect.Sync` which is translated to `CallbackTo` (the library is not generic for doing this). But if we ever decide to change the default sync effect, we don't have to change the code again, just the library dependency.