### PR TITLE
Fix useDebouncedTimeout hook.

### DIFF
--- a/js/src/main/scala/crystal/react/hooks/TimeoutHandle.scala
+++ b/js/src/main/scala/crystal/react/hooks/TimeoutHandle.scala
@@ -1,32 +1,38 @@
 package crystal.react.hooks
 
-import cats.effect.Fiber
-import cats.effect.Temporal
+import cats.Monoid
+import cats.effect.Async
+import cats.effect.Deferred
+import cats.effect.Ref
+import cats.effect.syntax.all._
 import cats.syntax.all._
-import crystal.react.implicits._
-import japgolly.scalajs.react.hooks.Hooks
-import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
-import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 
 import scala.concurrent.duration.FiniteDuration
 
-class TimeoutHandle(
-  duration:          FiniteDuration,
-  timerRef:          Hooks.UseRefF[DefaultS, Option[Fiber[DefaultA, Throwable, Unit]]]
-)(implicit DefaultA: Temporal[DefaultA]) {
-  private val cleanup: DefaultA[Unit] = timerRef.set(none).to[DefaultA]
+class TimeoutHandle[F[_]](
+  duration:   FiniteDuration,
+  latch:      Ref[F, Option[Deferred[F, TimeoutHandleLatch[F]]]]
+)(implicit F: Async[F], monoid: Monoid[F[Unit]]) {
 
-  val cancel: DefaultA[Unit] =
-    DefaultA.pure(timerRef.value) >>= (runningFiber =>
-      (cleanup >> runningFiber.map(_.cancel).orEmpty).uncancelable
+  private def switchTo(effect: F[Unit]): F[Unit] =
+    Deferred[F, TimeoutHandleLatch[F]] >>= (newLatch =>
+      latch
+        .modify(oldLatch =>
+          (newLatch.some,
+           for {
+             _        <- oldLatch.map(_.get.flatMap(_.cancel)).orEmpty
+             newFiber <- effect.start
+             _        <- newLatch.complete(newFiber)
+           } yield ()
+          )
+        )
+        .flatten
+        .uncancelable
     )
 
-  def submit(effect: DefaultA[Unit]): DefaultA[Unit] = {
-    val timedEffect =
-      // We don't cleanup until `effect` completes, so that we can still invoke `cancel` when the effect is running.
-      DefaultA.sleep(duration) >> effect.guarantee(cleanup.uncancelable)
-    cancel >>
-      (timedEffect.start >>=
-        (fiber => timerRef.set(fiber.some).to[DefaultA])).uncancelable
-  }
+  val cancel: F[Unit] = switchTo(F.unit)
+
+  // There's no need to clean up the fiber reference once the effect completes.
+  // Worst case scenario, cancel will be called on it, which will do nothing.
+  def submit(effect: F[Unit]): F[Unit] = switchTo(effect.delayBy(duration))
 }

--- a/js/src/main/scala/crystal/react/hooks/package.scala
+++ b/js/src/main/scala/crystal/react/hooks/package.scala
@@ -1,3 +1,7 @@
 package crystal.react
 
-package object hooks extends UseDebouncedTimeout.HooksApiExt
+import cats.effect.Fiber
+
+package object hooks extends UseDebouncedTimeout.HooksApiExt {
+  type TimeoutHandleLatch[F[_]] = Fiber[F, Throwable, Unit]
+}


### PR DESCRIPTION
The previous implementation was flawed and it would yield wrong results when called within a short period of time.

This new implementation fixed the problems by using the Ref+Deferred pattern as a latch, so that new invocations await until the previous one is completely enqueued.