### PR TITLE
Add ReuseView* classes for views with added reusability constraints.

### DIFF
--- a/js/src/main/scala/crystal/react/package.scala
+++ b/js/src/main/scala/crystal/react/package.scala
@@ -4,6 +4,8 @@ import cats.arrow.FunctionK
 import cats.effect.Async
 import cats.~>
 import crystal.react.implicits._
+import crystal.react.reuse.ReuseViewF
+import crystal.react.reuse.ReuseViewOptF
 import crystal.react.reuse.Reuse
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
@@ -43,8 +45,10 @@ package object react {
       StreamRenderer.build(s)
   }
 
-  type View[A]    = ViewF[DefaultS, A]
-  type ViewOpt[A] = ViewOptF[DefaultS, A]
+  type View[A]         = ViewF[DefaultS, A]
+  type ViewOpt[A]      = ViewOptF[DefaultS, A]
+  type ReuseView[A]    = ReuseViewF[DefaultS, A]
+  type ReuseViewOpt[A] = ReuseViewOptF[DefaultS, A]
 
   val syncToAsync: DefaultS ~> DefaultA = new FunctionK[DefaultS, DefaultA] { self =>
     def apply[A](fa: DefaultS[A]): DefaultA[A] = fa.to[DefaultA]

--- a/js/src/main/scala/crystal/react/reuse/ReuseViewF.scala
+++ b/js/src/main/scala/crystal/react/reuse/ReuseViewF.scala
@@ -1,0 +1,189 @@
+package crystal.react.reuse
+
+import cats.Id
+import cats.Monad
+import cats.Monoid
+import cats.effect.Async
+import cats.syntax.all._
+import crystal.ViewF
+import crystal.ViewListF
+import crystal.ViewOps
+import crystal.ViewOptF
+import japgolly.scalajs.react.Reusability
+import monocle.Iso
+import monocle.Lens
+import monocle.Optional
+import monocle.Prism
+import monocle.Traversal
+
+class ReuseViewF[F[_]: Monad, A](val rv: Reuse[ViewF[F, A]]) extends ViewOps[F, Id, A] {
+  val get: A                                           = rv.value.get
+  val modCB: ((A => A), A => F[Unit]) => F[Unit]       = rv.value.modCB
+  def modAndGet(f: A => A)(implicit F: Async[F]): F[A] = rv.value.modAndGet(f)
+
+  def map[B](f: ViewF[F, A] => ViewF[F, B]): ReuseViewF[F, B] =
+    ReuseViewF[F, B](rv.map(f))
+
+  def zoom[B](getB: A => B)(modB: (B => B) => A => A): ReuseViewF[F, B] = map(_.zoom(getB)(modB))
+
+  def zoomOpt[B](getB: A => Option[B])(modB: (B => B) => A => A): ReuseViewOptF[F, B] =
+    ReuseViewOptF(rv.map(_.zoomOpt(getB)(modB)))
+
+  def zoomList[B](
+    getB: A => List[B]
+  )(modB: (B => B) => A => A): ReuseViewListF[F, B] = ReuseViewListF(
+    rv.map(_.zoomList(getB)(modB))
+  )
+
+  def as[B](iso: Iso[A, B]): ReuseViewF[F, B] = zoom(iso.asLens)
+
+  def asOpt: ReuseViewOptF[F, A] = zoom(Iso.id[A].asOptional)
+
+  def asList: ReuseViewListF[F, A] = zoom(Iso.id[A].asTraversal)
+
+  def zoom[B](lens: Lens[A, B]): ReuseViewF[F, B] =
+    zoom(lens.get _)(lens.modify)
+
+  def zoom[B](optional: Optional[A, B]): ReuseViewOptF[F, B] =
+    zoomOpt(optional.getOption _)(optional.modify)
+
+  def zoom[B](prism: Prism[A, B]): ReuseViewOptF[F, B] =
+    zoomOpt(prism.getOption _)(prism.modify)
+
+  def zoom[B](traversal: Traversal[A, B]): ReuseViewListF[F, B] =
+    zoomList(traversal.getAll _)(traversal.modify)
+
+  def withOnMod(f: A => F[Unit]): ReuseViewF[F, A] = map(_.withOnMod(f))
+
+  def widen[B >: A]: ReuseViewF[F, B] = map(_.widen[B])
+
+  def unsafeNarrow[B <: A]: ReuseViewF[F, B] =
+    zoom(_.asInstanceOf[B])(modB => a => modB(a.asInstanceOf[B]))
+
+  def to[F1[_]: Monad](
+    toF1:   F[Unit] => F1[Unit],
+    fromF1: F1[Unit] => F[Unit]
+  ): ReuseViewF[F1, A] = ReuseViewF[F1, A](rv.map(_.to[F1](toF1, fromF1)))
+
+  def mapValue[B, C](f: ViewF[F, B] => C)(implicit ev: A =:= Option[B]): Option[C] =
+    get.map(a => f(rv.zoom(_ => a)(f => a1 => ev.flip(a1.map(f)))))
+
+  override def toString(): String = s"ReuseViewF($get, <modFn>)"
+}
+
+object ReuseViewF {
+  def apply[F[_]: Monad, A](rv: Reuse[ViewF[F, A]]): ReuseViewF[F, A] = new ReuseViewF(rv)
+
+  implicit def reuseReuseViewF[F[_], A]: Reusability[ReuseViewF[F, A]] = Reusability.by(_.rv)
+}
+
+class ReuseViewOptF[F[_]: Monad, A](val rvo: Reuse[ViewOptF[F, A]]) extends ViewOps[F, Option, A] {
+  val get: Option[A]                                           = rvo.value.get
+  val modCB: ((A => A), Option[A] => F[Unit]) => F[Unit]       = rvo.value.modCB
+  def modAndGet(f: A => A)(implicit F: Async[F]): F[Option[A]] = rvo.value.modAndGet(f)
+
+  def map[B](f: ViewOptF[F, A] => ViewOptF[F, B]): ReuseViewOptF[F, B] =
+    ReuseViewOptF[F, B](rvo.map(f))
+
+  def as[B](iso: Iso[A, B]): ReuseViewOptF[F, B] = zoom(iso.asLens)
+
+  def asList: ReuseViewListF[F, A] = zoom(Iso.id[A].asTraversal)
+
+  def zoom[B](getB: A => B)(modB: (B => B) => A => A): ReuseViewOptF[F, B] =
+    map(_.zoom(getB)(modB))
+
+  def zoomOpt[B](
+    getB: A => Option[B]
+  )(modB: (B => B) => A => A): ReuseViewOptF[F, B] =
+    map(_.zoomOpt(getB)(modB))
+
+  def zoomList[B](
+    getB: A => List[B]
+  )(modB: (B => B) => A => A): ReuseViewListF[F, B] =
+    ReuseViewListF(rvo.map(_.zoomList(getB)(modB)))
+
+  def zoom[B](lens: Lens[A, B]): ReuseViewOptF[F, B] =
+    zoom(lens.get _)(lens.modify)
+
+  def zoom[B](optional: Optional[A, B]): ReuseViewOptF[F, B] =
+    zoomOpt(optional.getOption)(optional.modify)
+
+  def zoom[B](prism: Prism[A, B]): ReuseViewOptF[F, B] =
+    zoomOpt(prism.getOption)(prism.modify)
+
+  def zoom[B](
+    traversal: Traversal[A, B]
+  ): ReuseViewListF[F, B] =
+    zoomList(traversal.getAll)(traversal.modify)
+
+  def withOnMod(f: Option[A] => F[Unit]): ReuseViewOptF[F, A] = map(_.withOnMod(f))
+
+  def widen[B >: A]: ReuseViewOptF[F, B] = map(_.widen[B])
+
+  def unsafeNarrow[B <: A]: ReuseViewOptF[F, B] = map(_.unsafeNarrow[B])
+
+  def mapValue[B](f: ViewF[F, A] => B)(implicit ev: Monoid[F[Unit]]): Option[B] =
+    get.map(a => f(ViewF[F, A](a, (mod, cb) => modCB(mod, _.foldMap(cb)))))
+
+  override def toString(): String = s"ReuseViewOptF($get, <modFn>)"
+}
+
+object ReuseViewOptF {
+  def apply[F[_]: Monad, A](rvo: Reuse[ViewOptF[F, A]]): ReuseViewOptF[F, A] =
+    new ReuseViewOptF(rvo)
+
+  implicit def reuseReuseViewOptF[F[_], A]: Reusability[ReuseViewOptF[F, A]] =
+    Reusability.by(_.rvo)
+}
+
+class ReuseViewListF[F[_]: Monad, A](val rvl: Reuse[ViewListF[F, A]]) extends ViewOps[F, List, A] {
+  val get: List[A]                                           = rvl.value.get
+  val modCB: ((A => A), List[A] => F[Unit]) => F[Unit]       = rvl.value.modCB
+  def modAndGet(f: A => A)(implicit F: Async[F]): F[List[A]] = rvl.value.modAndGet(f)
+
+  def map[B](f: ViewListF[F, A] => ViewListF[F, B]): ReuseViewListF[F, B] =
+    ReuseViewListF[F, B](rvl.map(f))
+
+  def as[B](iso: Iso[A, B]): ReuseViewListF[F, B] = zoom(iso.asLens)
+
+  def zoom[B](getB: A => B)(modB: (B => B) => A => A): ReuseViewListF[F, B] =
+    map(_.zoom(getB)(modB))
+
+  def zoomOpt[B](
+    getB: A => Option[B]
+  )(modB: (B => B) => A => A): ReuseViewListF[F, B] =
+    map(_.zoomOpt(getB)(modB))
+
+  def zoomList[B](
+    getB: A => List[B]
+  )(modB: (B => B) => A => A): ReuseViewListF[F, B] =
+    map(_.zoomList(getB)(modB))
+
+  def zoom[B](lens: Lens[A, B]): ReuseViewListF[F, B] =
+    zoom(lens.get _)(lens.modify)
+
+  def zoom[B](optional: Optional[A, B]): ReuseViewListF[F, B] =
+    zoomOpt(optional.getOption)(optional.modify)
+
+  def zoom[B](prism: Prism[A, B]): ReuseViewListF[F, B] =
+    zoomOpt(prism.getOption)(prism.modify)
+
+  def zoom[B](
+    traversal: Traversal[A, B]
+  ): ReuseViewListF[F, B] =
+    zoomList(traversal.getAll)(traversal.modify)
+
+  def withOnMod(f: List[A] => F[Unit]): ReuseViewListF[F, A] = map(_.withOnMod(f))
+
+  def widen[B >: A]: ReuseViewListF[F, B] = map(_.widen[B])
+
+  override def toString(): String = s"ReuseViewListF($get, <modFn>)"
+}
+
+object ReuseViewListF {
+  def apply[F[_]: Monad, A](rvl: Reuse[ViewListF[F, A]]): ReuseViewListF[F, A] =
+    new ReuseViewListF(rvl)
+
+  implicit def reuseReuseViewListF[F[_], A]: Reusability[ReuseViewListF[F, A]] =
+    Reusability.by(_.rvl)
+}

--- a/shared/src/main/scala/crystal/viewF.scala
+++ b/shared/src/main/scala/crystal/viewF.scala
@@ -11,7 +11,7 @@ import monocle.Optional
 import monocle.Prism
 import monocle.Traversal
 
-sealed abstract class ViewOps[F[_]: Monad, G[_], A] {
+abstract class ViewOps[F[_]: Monad, G[_], A] {
   val get: G[A]
 
   val setCB: (A, G[A] => F[Unit]) => F[Unit] = (a, cb) => modCB(_ => a, cb)
@@ -28,7 +28,7 @@ sealed abstract class ViewOps[F[_]: Monad, G[_], A] {
 // The difference between a View and a StateSnapshot is that the modifier doesn't act on the current value,
 // but passes the modifier function to an external source of truth. Since we are defining no getter
 // from such source of truth, a View is defined in terms of a modifier function instead of a setter.
-final class ViewF[F[_]: Monad, A](val get: A, val modCB: ((A => A), A => F[Unit]) => F[Unit])
+class ViewF[F[_]: Monad, A](val get: A, val modCB: ((A => A), A => F[Unit]) => F[Unit])
     extends ViewOps[F, Id, A] { self =>
   def modAndExtract[B](f: (A => (A, B)))(implicit F: Async[F]): F[B] =
     Async[F].async { cb =>


### PR DESCRIPTION
I have plumbed this all the way through Explore and it fixes the problem with the reusability in the target editor. The downside is that the `straight View*F` classes and the `ReuseView*F` classes really have the same interfaces and functionality, but can't be abstracted over. We have utilities like `toListOfViews` in explore and `zoomSplitEpi` that need to be repeated for the Reuse views. 

I have been trying to get a parameterized base class idea working, but there are a lot of types. For example, `ViewF` methods return not only new `ViewF`'s but also `ViewOptF`'s and `ViewListOptF`'s. I haven't been able to get all the types constrained so everything works completely correctly. I got it working for some cases, but chained methods on the base class don't work. I'm going to try a couple of other things, but such a solution may be beyond my type-fu.

Anyway, this is my general idea. Combining Reuse with the Views.

One of my goals was to keep the main `View` classes non-dependent on react, but still have the `Reuse` versions extend the ViewOps trait.     Another was to limit the changes that needed to be made in Explore to use the Reuse versions.

Other approaches would be:

- Making crystal dependent on react, and having all views incorporate reusability.
- Not have the Reuse versions extend the ViewOps trait, but use Reusable functions internally instead of wrapping in Reuse
- Only using the Reusable versions in Explore and other react libs/apps, instead of mixing the 2 versions. As it is, once you create a ReusableView, all the views downstream really need to be usable. So, we could start out at the beginning with the `extra reusability` (other than A) to be Always, and add additional reusability constraints as needed further down in the code. This should be fairly simple using type aliases.