### PR TITLE
Towards Reuse[View[A]].

### DIFF
--- a/js/src/main/scala/crystal/react/StateProvider.scala
+++ b/js/src/main/scala/crystal/react/StateProvider.scala
@@ -1,28 +1,17 @@
 package crystal.react
 
 import crystal.ViewF
-import crystal.react.reuse.Reuse
+import crystal.react.hooks._
+import crystal.react.reuse._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import japgolly.scalajs.react.vdom.html_<^._
-
-import implicits._
+import scala.reflect.ClassTag
 
 object StateProvider {
-
-  class Backend[M]($ : BackendScope[Reuse[ViewF[DefaultS, M] => VdomNode], M]) {
-    def render(props: Reuse[ViewF[DefaultS, M] => VdomNode]) =
-      props(ViewF.fromState($))
-  }
-
-  def apply[M](model: M)(implicit
-    reusabilityM:     Reusability[M]
-  ): StateComponent[M, Backend[M]] =
-    ScalaComponent
-      .builder[Reuse[ViewF[DefaultS, M] => VdomNode]]
-      .initialState(model)
-      .backend($ => new Backend($))
-      .renderBackend
-      .configure(Reusability.shouldComponentUpdate)
-      .build
+  def apply[M: ClassTag: Reusability](model: M) =
+    ScalaFnComponent
+      .withHooks[Reuse[ViewF[DefaultS, M]] ==> VdomNode]
+      .useStateViewWithReuse(model)
+      .renderWithReuse((f, state) => f(state))
 }

--- a/js/src/main/scala/crystal/react/StreamRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererMod.scala
@@ -11,14 +11,15 @@ import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.util.Effect.UnsafeSync
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{ Ref => _, _ }
+import japgolly.scalajs.react.{Ref => _, _}
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
 
 object StreamRendererMod {
 
-  type Props[A] = Pot[ViewF[DefaultS, A]] ==> VdomNode
+  type Props[A] = Pot[Reuse[ViewF[DefaultS, A]]] ==> VdomNode
 
   type State[A]     = Pot[A]
   type Component[A] =
@@ -29,13 +30,12 @@ object StreamRendererMod {
       _
     ]]
 
-  def build[F[_]: Async: Effect.Dispatch: Logger, A](
+  def build[F[_]: Async: Effect.Dispatch: Logger, A: ClassTag: Reusability](
     stream:       fs2.Stream[F, A],
     holdAfterMod: Option[FiniteDuration] = None
   )(implicit
     DefaultS:     Sync[DefaultS],
-    dispatch:     UnsafeSync[DefaultS],
-    reuse:        Reusability[A] /* Used to derive Reusability[State[A]] */
+    dispatch:     UnsafeSync[DefaultS]
   ): Component[A] = {
     class Backend($ : BackendScope[Props[A], State[A]])
         extends StreamRendererBackend[F, A](stream) {
@@ -56,14 +56,18 @@ object StreamRendererMod {
       ): VdomNode =
         props(
           state.map(a =>
-            ViewF[DefaultS, A](
-              a,
-              (f: A => A, cb: A => DefaultS[Unit]) =>
-                hold.enable.runAsync.flatMap(_ =>
-                  // I'm not very happy about the cast.
-                  // However, this is only executed when the pot is ready, so the cast should be safe.
-                  $.modState(_.map(f), $.state.flatMap(pot => cb(pot.asInstanceOf[Ready[A]].value)))
-                )
+            Reuse.by(a)(
+              ViewF[DefaultS, A](
+                a,
+                (f: A => A, cb: A => DefaultS[Unit]) =>
+                  hold.enable.runAsync.flatMap(_ =>
+                    // I'm not very happy about the cast.
+                    // However, this is only executed when the pot is ready, so the cast should be safe.
+                    $.modState(_.map(f),
+                               $.state.flatMap(pot => cb(pot.asInstanceOf[Ready[A]].value))
+                    )
+                  )
+              )
             )
           )
         )

--- a/js/src/main/scala/crystal/react/StreamRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererMod.scala
@@ -11,7 +11,7 @@ import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.util.Effect.UnsafeSync
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{Ref => _, _}
+import japgolly.scalajs.react.{ Ref => _, _ }
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.FiniteDuration

--- a/js/src/main/scala/crystal/react/hooks/SerialState.scala
+++ b/js/src/main/scala/crystal/react/hooks/SerialState.scala
@@ -1,7 +1,6 @@
 package crystal.react.hooks
 
 import japgolly.scalajs.react.Reusability
-import monocle.Lens
 
 case class SerialState[A] private (
   protected[hooks] val value:  A,
@@ -12,8 +11,6 @@ case class SerialState[A] private (
 
 object SerialState {
   def initial[A](value: A): SerialState[A] = SerialState(value)
-
-  def value[A]: Lens[SerialState[A], A] = Lens[SerialState[A], A](_.value)(v => _.update(_ => v))
 
   implicit def reuseSerialState[A]: Reusability[SerialState[A]] = Reusability.by(_.serial)
 }

--- a/js/src/main/scala/crystal/react/hooks/UseSerialStateView.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseSerialStateView.scala
@@ -1,17 +1,15 @@
 package crystal.react.hooks
 
 import crystal.react.View
-import japgolly.scalajs.react.Reusable
+import crystal.react.reuse._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.hooks.CustomHook
 
 object UseSerialStateView {
-  def hook[A]: CustomHook[A, Reusable[View[A]]] = CustomHook[A]
+  def hook[A]: CustomHook[A, Reuse[View[A]]] = CustomHook[A]
     .useStateViewBy(initialValue => SerialState.initial(initialValue))
     .buildReturning((_, serialStateView) =>
-      Reusable
-        .implicitly(serialStateView.get.serial)
-        .withValue(serialStateView.zoom(SerialState.value[A]))
+      Reuse.by(serialStateView.get.serial)(serialStateView.zoom(_.value)(mod => _.update(mod)))
     )
 
   object HooksApiExt {
@@ -20,13 +18,13 @@ object UseSerialStateView {
       /** Creates component state as a View that is reused while it's not updated. */
       final def useSerialStateView[A](initialValue: => A)(implicit
         step:                                       Step
-      ): step.Next[Reusable[View[A]]] =
+      ): step.Next[Reuse[View[A]]] =
         useSerialStateViewBy(_ => initialValue)
 
       /** Creates component state as a View that is reused while it's not updated. */
       final def useSerialStateViewBy[A](initialValue: Ctx => A)(implicit
         step:                                         Step
-      ): step.Next[Reusable[View[A]]] =
+      ): step.Next[Reuse[View[A]]] =
         api.customBy { ctx =>
           val hookInstance = hook[A]
           hookInstance(initialValue(ctx))
@@ -40,7 +38,7 @@ object UseSerialStateView {
       /** Creates component state as a View that is reused while it's not updated. */
       def useSerialStateViewBy[A](initialValue: CtxFn[A])(implicit
         step:                                   Step
-      ): step.Next[Reusable[View[A]]] =
+      ): step.Next[Reuse[View[A]]] =
         useSerialStateViewBy(step.squash(initialValue)(_))
     }
   }

--- a/js/src/main/scala/crystal/react/hooks/UseSingleEffect.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseSingleEffect.scala
@@ -9,6 +9,7 @@ import cats.syntax.all._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.hooks.CustomHook
 import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
 import scala.concurrent.duration.FiniteDuration
 
 class UseSingleEffect[F[_]](

--- a/js/src/main/scala/crystal/react/hooks/UseStateViewWithReuse.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStateViewWithReuse.scala
@@ -1,0 +1,84 @@
+package crystal.react.hooks
+
+import crystal.react.View
+import crystal.react.reuse.Reuse
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
+
+import scala.collection.immutable.Queue
+import scala.reflect.ClassTag
+
+object UseStateViewWithReuse {
+  def hook[A: ClassTag: Reusability]: CustomHook[A, Reuse[View[A]]] =
+    CustomHook[A]
+      .useStateBy(initialValue => initialValue)
+      .useRef(Queue.empty[A => DefaultS[Unit]])
+      // Credit to japgolly for this implementation; this is copied from StateSnapshot.
+      .useEffectBy { (_, state, delayedCallbacks) =>
+        val cbs = delayedCallbacks.value
+        if (cbs.isEmpty)
+          DefaultS.empty
+        else
+          delayedCallbacks.set(Queue.empty) >>
+            DefaultS.runAll(cbs.toList.map(_(state.value)): _*)
+      }
+      .buildReturning { (_, state, delayedCallbacks) =>
+        Reuse
+          .by(state.value)(
+            View[A](
+              state.value,
+              (f, cb) => state.modState(f) >> delayedCallbacks.mod(_.enqueue(cb))
+            )
+          )
+      }
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      /** Creates component state as a View */
+      final def useStateViewWithReuse[A: ClassTag: Reusability](initialValue: => A)(implicit
+        step:                                                                 Step
+      ): step.Next[Reuse[View[A]]] =
+        useStateViewWithReuseBy(_ => initialValue)
+
+      /** Creates component state as a View */
+      final def useStateViewWithReuseBy[A: ClassTag: Reusability](initialValue: Ctx => A)(implicit
+        step:                                                                   Step
+      ): step.Next[Reuse[View[A]]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(initialValue(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      /** Creates component state as a View */
+      def useStateViewWithReuseBy[A: ClassTag: Reusability](initialValue: CtxFn[A])(implicit
+        step:                                                             Step
+      ): step.Next[Reuse[View[A]]] =
+        useStateViewWithReuseBy(step.squash(initialValue)(_))
+    }
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtStateViewWithReuse1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtStateViewWithReuse2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx,
+                                                                                            CtxFn
+    ]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/package.scala
+++ b/js/src/main/scala/crystal/react/hooks/package.scala
@@ -6,6 +6,7 @@ package object hooks
     extends UseSingleEffect.HooksApiExt
     with UseSerialState.HooksApiExt
     with UseStateView.HooksApiExt
+    with UseStateViewWithReuse.HooksApiExt
     with UseSerialStateView.HooksApiExt {
   type UseSingleEffectLatch[F[_]] = Fiber[F, Throwable, Unit]
 }

--- a/js/src/main/scala/crystal/react/implicits/package.scala
+++ b/js/src/main/scala/crystal/react/implicits/package.scala
@@ -282,15 +282,6 @@ package object implicits {
       conv(view).to[DefaultA](syncToAsync.apply[Unit] _, _.runAsyncAndForget)
   }
 
-  implicit def viewReusability[F[_], A: Reusability]: Reusability[ViewF[F, A]] =
-    Reusability.by(_.get)
-
-  implicit def viewOptReusability[F[_], A: Reusability]: Reusability[ViewOptF[F, A]] =
-    Reusability.by(_.get)
-
-  implicit def viewListReusability[F[_], A: Reusability]: Reusability[ViewListF[F, A]] =
-    Reusability.by(_.get)
-
   implicit class ViewFModuleOps(private val viewFModule: ViewF.type) extends AnyVal {
     def fromState: FromStateView = new FromStateView
   }

--- a/js/src/main/scala/crystal/react/reuse/AppliedSyntax.scala
+++ b/js/src/main/scala/crystal/react/reuse/AppliedSyntax.scala
@@ -16,6 +16,9 @@ protected trait AppliedSyntax {
       Reuse.by(reuseByR)(valueA)
 
     def always: Reuse[A] = Reuse.by(())(valueA)
+
+    def self(implicit classTag: ClassTag[A], reusability: Reusability[A]): Reuse[A] =
+      Reuse.by(valueA)(valueA)
   }
 
   implicit class AppliedFn2Ops[A, R, S, B](aa: Applied[A])(implicit ev: A =:= ((R, S) => B)) {


### PR DESCRIPTION
This is part of a revamp aiming to privilege the use `Reuse[View[A]]`.

In this PR:
- New hook `useStateViewWithReuse` which provides a `Reuse[View[A]]`.
- `StreamRendererMod` now passes a `Reuse[View[A]]` to the render function.
- `Reusability[View*F[F, A]]` is removed.

Unrelated:
- Functional version of `StateProvider`, which evidences that it doesn't provide much beyond a simple `useStateViewWithReuse` hook, so it may completely go away in a future PR.
