### PR TITLE
ReuseView syntax and builder.

### DIFF
--- a/js/src/main/scala/crystal/react/StateProvider.scala
+++ b/js/src/main/scala/crystal/react/StateProvider.scala
@@ -1,17 +1,16 @@
 package crystal.react
 
-import crystal.ViewF
 import crystal.react.hooks._
 import crystal.react.reuse._
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import japgolly.scalajs.react.vdom.html_<^._
+
 import scala.reflect.ClassTag
 
 object StateProvider {
   def apply[M: ClassTag: Reusability](model: M) =
     ScalaFnComponent
-      .withHooks[Reuse[ViewF[DefaultS, M]] ==> VdomNode]
+      .withHooks[ReuseView[M] ==> VdomNode]
       .useStateViewWithReuse(model)
       .renderWithReuse((f, state) => f(state))
 }

--- a/js/src/main/scala/crystal/react/StreamRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererMod.scala
@@ -19,7 +19,7 @@ import scala.reflect.ClassTag
 
 object StreamRendererMod {
 
-  type Props[A] = Pot[Reuse[ViewF[DefaultS, A]]] ==> VdomNode
+  type Props[A] = Pot[ReuseView[A]] ==> VdomNode
 
   type State[A]     = Pot[A]
   type Component[A] =
@@ -50,14 +50,11 @@ object StreamRendererMod {
         pot =>
           hold.set(pot) >> hold.enable // This will debounce messages for at least the hold time.
 
-      def render(
-        props: Props[A],
-        state: Pot[A]
-      ): VdomNode =
+      def render(props: Props[A], state: Pot[A]): VdomNode =
         props(
           state.map(a =>
             Reuse.by(a)(
-              ViewF[DefaultS, A](
+              View[A](
                 a,
                 (f: A => A, cb: A => DefaultS[Unit]) =>
                   hold.enable.runAsync.flatMap(_ =>

--- a/js/src/main/scala/crystal/react/hooks/UseSerialStateView.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseSerialStateView.scala
@@ -1,12 +1,12 @@
 package crystal.react.hooks
 
-import crystal.react.View
+import crystal.react.ReuseView
 import crystal.react.reuse._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.hooks.CustomHook
 
 object UseSerialStateView {
-  def hook[A]: CustomHook[A, Reuse[View[A]]] = CustomHook[A]
+  def hook[A]: CustomHook[A, ReuseView[A]] = CustomHook[A]
     .useStateViewBy(initialValue => SerialState.initial(initialValue))
     .buildReturning((_, serialStateView) =>
       Reuse.by(serialStateView.get.serial)(serialStateView.zoom(_.value)(mod => _.update(mod)))
@@ -18,13 +18,13 @@ object UseSerialStateView {
       /** Creates component state as a View that is reused while it's not updated. */
       final def useSerialStateView[A](initialValue: => A)(implicit
         step:                                       Step
-      ): step.Next[Reuse[View[A]]] =
+      ): step.Next[ReuseView[A]] =
         useSerialStateViewBy(_ => initialValue)
 
       /** Creates component state as a View that is reused while it's not updated. */
       final def useSerialStateViewBy[A](initialValue: Ctx => A)(implicit
         step:                                         Step
-      ): step.Next[Reuse[View[A]]] =
+      ): step.Next[ReuseView[A]] =
         api.customBy { ctx =>
           val hookInstance = hook[A]
           hookInstance(initialValue(ctx))
@@ -38,7 +38,7 @@ object UseSerialStateView {
       /** Creates component state as a View that is reused while it's not updated. */
       def useSerialStateViewBy[A](initialValue: CtxFn[A])(implicit
         step:                                   Step
-      ): step.Next[Reuse[View[A]]] =
+      ): step.Next[ReuseView[A]] =
         useSerialStateViewBy(step.squash(initialValue)(_))
     }
   }

--- a/js/src/main/scala/crystal/react/implicits/package.scala
+++ b/js/src/main/scala/crystal/react/implicits/package.scala
@@ -284,6 +284,8 @@ package object implicits {
 
   implicit class ViewFModuleOps(private val viewFModule: ViewF.type) extends AnyVal {
     def fromState: FromStateView = new FromStateView
+
+    def fromStateWithReuse = new FromStateReuseView
   }
 
   implicit class ViewFReuseOps[F[_], G[_], A](private val viewF: ViewOps[F, G, A]) extends AnyVal {

--- a/js/src/main/scala/crystal/react/reuse/package.scala
+++ b/js/src/main/scala/crystal/react/reuse/package.scala
@@ -8,12 +8,12 @@ import crystal.ViewF
 import crystal.ViewListF
 import crystal.ViewOptF
 import crystal.react.reuse.Reuse
+import japgolly.scalajs.react.Reusability
 import monocle.Iso
 import monocle.Lens
 import monocle.Optional
 import monocle.Prism
 import monocle.Traversal
-import japgolly.scalajs.react.Reusability
 
 import scala.reflect.ClassTag
 

--- a/shared/src/test/scala/crystal/PotSpec.scala
+++ b/shared/src/test/scala/crystal/PotSpec.scala
@@ -1,19 +1,21 @@
 package crystal
 
-import munit.DisciplineSuite
-import arbitraries._
-import cats.syntax.all._
 import cats.kernel.laws.discipline.EqTests
-import org.scalacheck.Prop.forAll
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.syntax.all._
 import crystal.implicits._
 import crystal.implicits.throwable._
+import munit.DisciplineSuite
+import org.scalacheck.Prop
+import org.scalacheck.Prop.forAll
+
 import scala.util.Failure
 import scala.util.Success
-import org.scalacheck.Prop
 import scala.util.Try
+
+import arbitraries._
 
 class PotSpec extends DisciplineSuite {
   implicit def iso: Isomorphisms[Pot] = Isomorphisms.invariant[Pot]

--- a/shared/src/test/scala/crystal/ViewFSpec.scala
+++ b/shared/src/test/scala/crystal/ViewFSpec.scala
@@ -1,8 +1,9 @@
 package crystal
 
-import cats.syntax.all._
+import cats.effect.Deferred
 import cats.effect.IO
-import cats.effect.{ Deferred, Ref }
+import cats.effect.Ref
+import cats.syntax.all._
 
 class ViewFSpec extends munit.CatsEffectSuite {
 

--- a/shared/src/test/scala/crystal/ViewListFSpec.scala
+++ b/shared/src/test/scala/crystal/ViewListFSpec.scala
@@ -1,9 +1,10 @@
 package crystal
 
-import cats.syntax.all._
+import cats.effect.Deferred
 import cats.effect.IO
+import cats.effect.Ref
+import cats.syntax.all._
 import monocle.Traversal
-import cats.effect.{ Deferred, Ref }
 
 class ViewListFSpec extends munit.CatsEffectSuite {
 

--- a/shared/src/test/scala/crystal/ViewOptFSpec.scala
+++ b/shared/src/test/scala/crystal/ViewOptFSpec.scala
@@ -1,9 +1,10 @@
 package crystal
 
-import cats.syntax.all._
+import cats.effect.Deferred
 import cats.effect.IO
+import cats.effect.Ref
+import cats.syntax.all._
 import monocle.std.option.some
-import cats.effect.{ Deferred, Ref }
 
 class ViewOptFSpec extends munit.CatsEffectSuite {
 

--- a/shared/src/test/scala/crystal/arbitraries.scala
+++ b/shared/src/test/scala/crystal/arbitraries.scala
@@ -1,6 +1,7 @@
 package crystal
 
 import org.scalacheck._
+
 import Arbitrary._
 import Gen._
 

--- a/shared/src/test/scala/crystal/package.scala
+++ b/shared/src/test/scala/crystal/package.scala
@@ -1,10 +1,10 @@
 import cats.Eq
-import monocle.Optional
-import monocle.Traversal
-import monocle.std.option.some
 import monocle.Iso
 import monocle.Lens
+import monocle.Optional
+import monocle.Traversal
 import monocle.macros.GenLens
+import monocle.std.option.some
 
 package crystal {
   case class Wrap[A](a: A) {


### PR DESCRIPTION
Simplify syntax whenever possible by using available type aliases.

Add a `ReuseView` constructor and `View.fromStateWithReuse($)`.