### PR TITLE
Convenience methods

### DIFF
--- a/js/src/main/scala/crystal/react/StreamRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererMod.scala
@@ -53,19 +53,15 @@ object StreamRendererMod {
       def render(props: Props[A], state: Pot[A]): VdomNode =
         props(
           state.map(a =>
-            Reuse.by(a)(
-              View[A](
-                a,
-                (f: A => A, cb: A => DefaultS[Unit]) =>
-                  hold.enable.runAsync.flatMap(_ =>
-                    // I'm not very happy about the cast.
-                    // However, this is only executed when the pot is ready, so the cast should be safe.
-                    $.modState(_.map(f),
-                               $.state.flatMap(pot => cb(pot.asInstanceOf[Ready[A]].value))
-                    )
-                  )
-              )
-            )
+            View[A](
+              a,
+              (f: A => A, cb: A => DefaultS[Unit]) =>
+                hold.enable.runAsync.flatMap(_ =>
+                  // I'm not very happy about the cast.
+                  // However, this is only executed when the pot is ready, so the cast should be safe.
+                  $.modState(_.map(f), $.state.flatMap(pot => cb(pot.asInstanceOf[Ready[A]].value)))
+                )
+            ).reuseByValue
           )
         )
     }

--- a/js/src/main/scala/crystal/react/implicits/package.scala
+++ b/js/src/main/scala/crystal/react/implicits/package.scala
@@ -16,6 +16,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import monocle.Lens
 import org.typelevel.log4cats.Logger
 
+import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
 package object implicits {
@@ -276,26 +277,28 @@ package object implicits {
       }
     )
 
-  // The implicit conversion dance is mainly to deal with Reusable[View]
-  implicit class ViewDefaultSOps[A, V](private val view: V)(implicit conv: V => View[A]) {
-    def async: ViewF[DefaultA, A] =
-      conv(view).to[DefaultA](syncToAsync.apply[Unit] _, _.runAsyncAndForget)
+  implicit class ViewDefaultSOps[A](private val view: View[A]) {
+    def async(implicit logger: Logger[DefaultA]): ViewF[DefaultA, A] =
+      view.to[DefaultA](syncToAsync.apply[Unit] _, _.runAsync)
+  }
+
+  implicit class ViewFOps[F[_], A: ClassTag: Reusability](private val view: ViewF[F, A]) {
+    def reuseByValue: Reuse[ViewF[F, A]] = Reuse.by(view.get)(view)
   }
 
   implicit class ViewFModuleOps(private val viewFModule: ViewF.type) extends AnyVal {
     def fromState: FromStateView = new FromStateView
-
-    def fromStateWithReuse = new FromStateReuseView
   }
 
-  implicit class ViewFReuseOps[F[_], G[_], A](private val viewF: ViewOps[F, G, A]) extends AnyVal {
-    def reuseSet: Reuse[A => F[Unit]] = Reuse.always(viewF.set)
-
-    def reuseMod: Reuse[(A => A) => F[Unit]] = Reuse.always(viewF.mod)
-
-    def reuseModAndGet(implicit F: Async[F]): Reuse[(A => A) => F[G[A]]] =
-      Reuse.always(viewF.modAndGet)
+  implicit class ViewOptFOps[F[_], A: ClassTag: Reusability](private val view: ViewOptF[F, A]) {
+    def reuseByValue: Reuse[ViewOptF[F, A]] = Reuse.by(view.get)(view)
   }
+
+  implicit class ReuseViewDefaultSOps[A](private val view: ReuseView[A]) {
+    def async(implicit logger: Logger[DefaultA]): ReuseViewF[DefaultA, A] =
+      view.to[DefaultA](syncToAsync.apply[Unit] _, _.runAsync)
+  }
+
 }
 
 package implicits {

--- a/js/src/main/scala/crystal/react/package.scala
+++ b/js/src/main/scala/crystal/react/package.scala
@@ -62,6 +62,8 @@ package react {
       value: A,
       modCB: ((A => A), A => DefaultS[Unit]) => DefaultS[Unit]
     ): View[A] = ViewF[DefaultS, A](value, modCB)
+
+    def fromState = new FromStateView
   }
 
   class FromStateView {
@@ -80,7 +82,9 @@ package react {
       value: A,
       modCB: ((A => A), A => DefaultS[Unit]) => DefaultS[Unit]
     ): ReuseView[A] =
-      Reuse.by(value)(View(value, modCB))
+      View(value, modCB).reuseByValue
+
+    def fromState = new FromStateReuseView
   }
 
   class FromStateReuseView {


### PR DESCRIPTION
- Adds convenience method `.reuseByValue` to `View*F`.
- Adds `async` method to `ReuseView`.
- Rename `ViewF.fromStateWithReuse` to `ReuseView.fromState`, add `View.fromState`.