### PR TITLE
More hooks: UseAsyncEffect(OnMount), UseResource. StreamResourceRenderer(Mod). UseRef async convenience methods.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,8 @@ lazy val crystal = crossProject(JVMPlatform, JSPlatform)
   )
   .jsSettings(
     libraryDependencies ++=
-      Settings.Libraries.ReactScalaJS.value,
+      Settings.Libraries.ScalaJSReact.value ++
+        Settings.Libraries.ReactCommon.value,
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
 

--- a/js/src/main/scala/crystal/react/StreamResourceRenderer.scala
+++ b/js/src/main/scala/crystal/react/StreamResourceRenderer.scala
@@ -1,0 +1,45 @@
+package crystal.react
+
+import cats.effect.kernel.Resource
+import crystal.Pot
+import crystal._
+import crystal.react.StreamRenderer
+import crystal.react.hooks._
+import crystal.react.reuse._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+import japgolly.scalajs.react.vdom.html_<^._
+import org.typelevel.log4cats.Logger
+import _root_.react.common.ReactFnProps
+
+final case class StreamResourceRenderer[A](
+  resource:           Resource[DefaultA, fs2.Stream[DefaultA, A]],
+  render:             Pot[A] ==> VdomNode
+)(implicit val reuse: Reusability[A], val logger: Logger[DefaultA])
+    extends ReactFnProps[StreamResourceRenderer[Any]](StreamResourceRenderer.component)
+
+object StreamResourceRenderer {
+  type Props[A] = StreamResourceRenderer[A]
+
+  private def componentBuilder[A] =
+    ScalaFnComponent
+      .withHooks[Props[A]]
+      .useResourceBy { props =>
+        import props.reuse
+        import props.logger
+
+        props.resource.map(StreamRenderer.build[DefaultA, A])
+      }
+      .render((props, component) =>
+        // The same Pot rendering function is used for rendering the Pot[Component]
+        // while the Resource is being allocated/is errored, and for rendering the
+        // Pot[A] obtained from the stream.
+        component match {
+          case p @ Pending(_) => props.render(p)
+          case e @ Error(_)   => props.render(e)
+          case Ready(comp)    => comp(props.render)
+        }
+      )
+
+  val component = componentBuilder[Any]
+}

--- a/js/src/main/scala/crystal/react/StreamResourceRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamResourceRendererMod.scala
@@ -1,0 +1,58 @@
+package crystal.react
+
+import cats.effect.Sync
+import cats.effect.kernel.Resource
+import crystal.Pot
+import crystal._
+import crystal.react.StreamRendererMod
+import crystal.react.hooks._
+import crystal.react.reuse._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
+import japgolly.scalajs.react.util.Effect.UnsafeSync
+import japgolly.scalajs.react.vdom.html_<^._
+import org.typelevel.log4cats.Logger
+import _root_.react.common.ReactFnProps
+
+import scala.reflect.ClassTag
+
+final case class StreamResourceRendererMod[A](
+  resource:     Resource[DefaultA, fs2.Stream[DefaultA, A]],
+  render:       Pot[ReuseView[A]] ==> VdomNode
+)(implicit
+  val reuse:    Reusability[A],
+  val classTag: ClassTag[A],
+  val DefaultS: Sync[DefaultS],
+  val dispatch: UnsafeSync[DefaultS],
+  val logger:   Logger[DefaultA]
+) extends ReactFnProps[StreamResourceRendererMod[Any]](StreamResourceRendererMod.component)
+
+object StreamResourceRendererMod {
+  type Props[A] = StreamResourceRendererMod[A]
+
+  private def componentBuilder[A] =
+    ScalaFnComponent
+      .withHooks[Props[A]]
+      .useResourceBy { props =>
+        import props.reuse
+        import props.classTag
+        import props.logger
+        import props.DefaultS
+        import props.dispatch
+
+        props.resource.map(stream => StreamRendererMod.build[DefaultA, A](stream))
+      }
+      .render((props, component) =>
+        // The same Pot rendering function is used for rendering the Pot[Component]
+        // while the Resource is being allocated/is errored, and for rendering the
+        // Pot[A] obtained from the stream.
+        component match {
+          case p @ Pending(_) => props.render(p)
+          case e @ Error(_)   => props.render(e)
+          case Ready(comp)    => comp(props.render)
+        }
+      )
+
+  val component = componentBuilder[Any]
+}

--- a/js/src/main/scala/crystal/react/hooks/UseAsyncEffect.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseAsyncEffect.scala
@@ -1,0 +1,75 @@
+package crystal.react.hooks
+
+import cats.syntax.all._
+import crystal.react.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
+// TODO PR to scalajs-react changing implicit not found message
+object UseAsyncEffect {
+
+  val hook = CustomHook[DefaultA[DefaultA[Unit]]]
+    .useRef(none[DefaultA[Unit]])
+    .useEffectBy((effect, cleanupEffect) =>
+      effect
+        .flatMap(f => cleanupEffect.setAsync(f.some))
+        .runAsyncAndForget
+        .as(cleanupEffect.get.flatMap(_.foldMap(_.runAsyncAndForget)))
+    )
+    .build
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
+        * without a cleanup callback, just use the regular `useEffect` hook.
+        */
+      final def useAsyncEffect[A](effect: DefaultA[DefaultA[Unit]])(implicit
+        step:                             Step
+      ): step.Self =
+        useAsyncEffectBy(_ => effect)
+
+      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
+        * without a cleanup callback, just use the regular `useEffect` hook.
+        */
+      final def useAsyncEffectBy[A](effect: Ctx => DefaultA[DefaultA[Unit]])(implicit
+        step:                               Step
+      ): step.Self =
+        api.customBy { ctx =>
+          val hookInstance = hook
+          hookInstance(effect(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
+        * without a cleanup callback, just use the regular `useEffect` hook.
+        */
+      def useAsyncEffectBy[A](effect: CtxFn[DefaultA[DefaultA[Unit]]])(implicit
+        step:                         Step
+      ): step.Self =
+        useAsyncEffectBy(step.squash(effect)(_))
+    }
+
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtAsyncEffect1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtAsyncEffect2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/UseAsyncEffectOnMount.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseAsyncEffectOnMount.scala
@@ -1,0 +1,77 @@
+package crystal.react.hooks
+
+import cats.syntax.all._
+import crystal.react.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
+// TODO PR to scalajs-react changing implicit not found message
+object UseAsyncEffectOnMount {
+
+  val hook = CustomHook[DefaultA[DefaultA[Unit]]]
+    .useRef(none[DefaultA[Unit]])
+    .useEffectOnMountBy((effect, cleanup) =>
+      effect
+        .flatMap(f => cleanup.setAsync(f.some))
+        .runAsyncAndForget
+        .as(cleanup.get.flatMap(_.foldMap(_.runAsyncAndForget)))
+    )
+    .build
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
+        * without a cleanup callback, just use the regular `useEffect` hook.
+        */
+      final def useAsyncEffectOnMount[A](effect: DefaultA[DefaultA[Unit]])(implicit
+        step:                                    Step
+      ): step.Self =
+        useAsyncEffectOnMountBy(_ => effect)
+
+      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
+        * without a cleanup callback, just use the regular `useEffect` hook.
+        */
+      final def useAsyncEffectOnMountBy[A](effect: Ctx => DefaultA[DefaultA[Unit]])(implicit
+        step:                                      Step
+      ): step.Self =
+        api.customBy { ctx =>
+          val hookInstance = hook
+          hookInstance(effect(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
+        * without a cleanup callback, just use the regular `useEffect` hook.
+        */
+      def useAsyncEffectOnMountBy[A](effect: CtxFn[DefaultA[DefaultA[Unit]]])(implicit
+        step:                                Step
+      ): step.Self =
+        useAsyncEffectOnMountBy(step.squash(effect)(_))
+    }
+
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtAsyncEffectOnMount1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtAsyncEffectOnMount2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx,
+                                                                                            CtxFn
+    ]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/UseAsyncEffectOnMount.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseAsyncEffectOnMount.scala
@@ -22,16 +22,16 @@ object UseAsyncEffectOnMount {
   object HooksApiExt {
     sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
 
-      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-        * without a cleanup callback, just use the regular `useEffect` hook.
+      /** Simulates `useEffectOnMount` with cleanup callback for async effect. To declare an async
+        * effect without a cleanup callback, just use the regular `useEffectOnMount` hook.
         */
       final def useAsyncEffectOnMount[A](effect: DefaultA[DefaultA[Unit]])(implicit
         step:                                    Step
       ): step.Self =
         useAsyncEffectOnMountBy(_ => effect)
 
-      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-        * without a cleanup callback, just use the regular `useEffect` hook.
+      /** Simulates `useEffectOnMount` with cleanup callback for async effect. To declare an async
+        * effect without a cleanup callback, just use the regular `useEffectOnMount` hook.
         */
       final def useAsyncEffectOnMountBy[A](effect: Ctx => DefaultA[DefaultA[Unit]])(implicit
         step:                                      Step
@@ -46,8 +46,8 @@ object UseAsyncEffectOnMount {
       api: HooksApi.Secondary[Ctx, CtxFn, Step]
     ) extends Primary[Ctx, Step](api) {
 
-      /** Simulates `useEffect` with cleanup callback for async effect. To declare an async effect
-        * without a cleanup callback, just use the regular `useEffect` hook.
+      /** Simulates `useEffectOnMount` with cleanup callback for async effect. To declare an async
+        * effect without a cleanup callback, just use the regular `useEffectOnMount` hook.
         */
       def useAsyncEffectOnMountBy[A](effect: CtxFn[DefaultA[DefaultA[Unit]]])(implicit
         step:                                Step

--- a/js/src/main/scala/crystal/react/hooks/UseResource.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseResource.scala
@@ -1,0 +1,73 @@
+package crystal.react.hooks
+
+import cats.effect.Resource
+import crystal.Pot
+import crystal.implicits._
+import crystal.react.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
+// TODO Functional streamrender* components
+object UseResource {
+  def hook[A] = CustomHook[Resource[DefaultA, A]]
+    .useState(Pot.pending[A])
+    .useAsyncEffectOnMountBy((resource, state) =>
+      resource.allocated
+        .flatMap { case (value, close) =>
+          state.setStateAsync(value.ready).as(close)
+        }
+        .handleErrorWith(t => state.setStateAsync(Pot.error(t)))
+        .as(DefaultA.delay(()))
+    )
+    .buildReturning((_, state) => state.value)
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      /** Open a `Resource[Async, A] on mount and close it on unmount. Provided as a `Pot[A]`. Will
+        * rerender when the `Pot` state changes.
+        */
+      final def useResource[A](resource: Resource[DefaultA, A])(implicit
+        step:                            Step
+      ): step.Next[Pot[A]] =
+        useResourceBy(_ => resource)
+
+      /** Creates component state that is reused while it's not updated. */
+      final def useResourceBy[A](resource: Ctx => Resource[DefaultA, A])(implicit
+        step:                              Step
+      ): step.Next[Pot[A]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(resource(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      /** Creates component state that is reused while it's not updated. */
+      def useResourceBy[A](resource: CtxFn[Resource[DefaultA, A]])(implicit
+        step:                        Step
+      ): step.Next[Pot[A]] =
+        useResourceBy(step.squash(resource)(_))
+    }
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtResource1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtResource2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/package.scala
+++ b/js/src/main/scala/crystal/react/hooks/package.scala
@@ -7,6 +7,9 @@ package object hooks
     with UseSerialState.HooksApiExt
     with UseStateView.HooksApiExt
     with UseStateViewWithReuse.HooksApiExt
-    with UseSerialStateView.HooksApiExt {
+    with UseSerialStateView.HooksApiExt
+    with UseAsyncEffect.HooksApiExt
+    with UseAsyncEffectOnMount.HooksApiExt
+    with UseResource.HooksApiExt {
   type UseSingleEffectLatch[F[_]] = Fiber[F, Throwable, Unit]
 }

--- a/js/src/main/scala/crystal/react/implicits/package.scala
+++ b/js/src/main/scala/crystal/react/implicits/package.scala
@@ -117,7 +117,7 @@ package object implicits {
       }
   }
 
-  implicit class UseStateFOps[S](private val self: Hooks.UseStateF[DefaultS, S]) extends AnyVal {
+  implicit class UseStateOps[S](private val self: Hooks.UseState[S]) extends AnyVal {
     @inline def setStateAsync: Reusable[S => DefaultA[Unit]] =
       self.setState.map(f => s => f(s).to[DefaultA])
 
@@ -128,13 +128,21 @@ package object implicits {
       new WithReusableInputsAsync[S](self)
   }
 
-  implicit class UseStateWithReuseFOps[S](private val self: Hooks.UseStateWithReuseF[DefaultS, S])
+  implicit class UseStateWithReuseOps[S](private val self: Hooks.UseStateWithReuse[S])
       extends AnyVal {
     @inline def setStateAsync: Reusable[S => Reusable[DefaultA[Unit]]] =
       self.setState.map(f => s => f(s).map(_.to[DefaultA]))
 
     @inline def modStateAsync(f: S => S): Reusable[DefaultA[Unit]] =
       self.modState(f).map(_.to[DefaultA])
+  }
+
+  implicit class UseRefOps[A](private val self: Hooks.UseRef[A]) extends AnyVal {
+    @inline def setAsync: A => DefaultA[Unit] = a => self.set(a).to[DefaultA]
+
+    @inline def modAsync: (A => A) => DefaultA[Unit] = f => self.mod(f).to[DefaultA]
+
+    @inline def getAsync: DefaultA[A] = self.get.to[DefaultA]
   }
 
   implicit class EffectAOps[F[_], A](private val self: F[A]) extends AnyVal {

--- a/js/src/main/scala/crystal/react/reuse/Reuse.scala
+++ b/js/src/main/scala/crystal/react/reuse/Reuse.scala
@@ -63,12 +63,11 @@ trait Reuse[+A] {
 
 object Reuse extends AppliedSyntax with CurryingSyntax with CurrySyntax with ReusableInterop {
   implicit def reusability[A]: Reusability[Reuse[A]] =
-    Reusability.apply((reuseA, reuseB) =>
-      if (reuseA.classTag == reuseB.classTag)
-        reuseA.reusability.test(reuseA.reuseBy, reuseB.reuseBy.asInstanceOf[reuseA.B]) &&
-        reuseB.reusability.test(reuseA.reuseBy.asInstanceOf[reuseB.B], reuseB.reuseBy)
-      else false
-    )
+    Reusability.apply { (reuseA, reuseB) =>
+      reuseA.classTag == reuseB.classTag &&
+      reuseA.reusability.test(reuseA.reuseBy, reuseB.reuseBy.asInstanceOf[reuseA.B]) &&
+      reuseB.reusability.test(reuseA.reuseBy.asInstanceOf[reuseB.B], reuseB.reuseBy)
+    }
 
   /*
    * Constructs a `Reuse[A]` by using the pattern `Reuse.by(valueWithReusability)(reusedValue)`.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,28 +5,21 @@ import sbt.librarymanagement._
 object Settings {
 
   object LibraryVersions {
-    val scalajsReact    = "2.1.1"
     val cats            = "2.7.0"
     val catsEffect      = "3.3.11"
-    val fs2             = "3.2.7"
-    val monocle         = "3.1.0"
-    val log4Cats        = "2.3.0"
-    val mUnit           = "0.7.29"
-    val mUnitCatsEffect = "1.0.7"
     val discipline      = "1.5.1"
     val disciplineMUnit = "1.0.9"
+    val fs2             = "3.2.7"
+    val log4Cats        = "2.3.0"
+    val monocle         = "3.1.0"
+    val mUnit           = "0.7.29"
+    val mUnitCatsEffect = "1.0.7"
+    val reactCommon     = "0.17.0"
+    val scalajsReact    = "2.1.1"
   }
 
   object Libraries {
     import LibraryVersions._
-
-    val ReactScalaJS = Def.setting(
-      Seq(
-        "com.github.japgolly.scalajs-react" %%% "core-bundle-cb_io"  % scalajsReact,
-        "com.github.japgolly.scalajs-react" %%% "extra"              % scalajsReact,
-        "com.github.japgolly.scalajs-react" %%% "extra-ext-monocle3" % scalajsReact
-      )
-    )
 
     val CatsJS = Def.setting(
       Seq[ModuleID](
@@ -40,35 +33,9 @@ object Settings {
       )
     )
 
-    val Fs2JS = Def.setting(
+    val CatsLaws = Def.setting(
       Seq[ModuleID](
-        "co.fs2" %%% "fs2-core" % fs2
-      )
-    )
-
-    val Monocle = Def.setting(
-      Seq[ModuleID](
-        "dev.optics" %%% "monocle-core" % monocle
-      )
-    )
-
-    val MonocleMacro = Def.setting(
-      Seq[ModuleID](
-        "dev.optics" %%% "monocle-macro" % monocle
-      )
-    )
-
-    val Log4Cats = Def.setting(
-      Seq[ModuleID](
-        "org.typelevel" %%% "log4cats-core" % log4Cats
-      )
-    )
-
-    val MUnit = Def.setting(
-      Seq[ModuleID](
-        "org.scalameta" %%% "munit"               % mUnit,
-        "org.scalameta" %%% "munit-scalacheck"    % mUnit,
-        "org.typelevel" %%% "munit-cats-effect-3" % mUnitCatsEffect
+        "org.typelevel" %%% "cats-laws" % cats
       )
     )
 
@@ -84,11 +51,53 @@ object Settings {
       )
     )
 
-    val CatsLaws = Def.setting(
+    val Fs2JS = Def.setting(
       Seq[ModuleID](
-        "org.typelevel" %%% "cats-laws" % cats
+        "co.fs2" %%% "fs2-core" % fs2
       )
     )
+
+    val Log4Cats = Def.setting(
+      Seq[ModuleID](
+        "org.typelevel" %%% "log4cats-core" % log4Cats
+      )
+    )
+
+    val Monocle = Def.setting(
+      Seq[ModuleID](
+        "dev.optics" %%% "monocle-core" % monocle
+      )
+    )
+
+    val MonocleMacro = Def.setting(
+      Seq[ModuleID](
+        "dev.optics" %%% "monocle-macro" % monocle
+      )
+    )
+
+    val MUnit = Def.setting(
+      Seq[ModuleID](
+        "org.scalameta" %%% "munit"               % mUnit,
+        "org.scalameta" %%% "munit-scalacheck"    % mUnit,
+        "org.typelevel" %%% "munit-cats-effect-3" % mUnitCatsEffect
+      )
+    )
+
+    val ReactCommon = Def.setting(
+      Seq[ModuleID](
+        "io.github.cquiroz.react" %%% "common" % reactCommon,
+        "io.github.cquiroz.react" %%% "cats"   % reactCommon
+      )
+    )
+
+    val ScalaJSReact = Def.setting(
+      Seq[ModuleID](
+        "com.github.japgolly.scalajs-react" %%% "core-bundle-cb_io"  % scalajsReact,
+        "com.github.japgolly.scalajs-react" %%% "extra"              % scalajsReact,
+        "com.github.japgolly.scalajs-react" %%% "extra-ext-monocle3" % scalajsReact
+      )
+    )
+
   }
 
 }


### PR DESCRIPTION
- New hooks:
  - If we want to `useEffect` with an async effect and return a cleanup effect, this doesn't really work in scalajs-react since it needs us to synchronously return the cleanup effect. `useAsyncEffect` and `useAsyncEffectOnMount` allow us to do this.
  - `useResource`: Given a (CE) `Resource[A]`, it will allocate it on mount and close in on unmount, providing a `Pot[A]` to the render function.
-  `StreamResourceRenderer` and `StreamResourceRendererMod` are similar to `StreamRenderer` and `StreamRendererMod` but they take as input a `Resource[Stream[A]]` instead of a `Stream[A]`. The resource will be allocated upon mounting and closed upon unmounting.
- When using `useRef` we can now call `getAsync`, `setAsync` and `modAsync`.