### PR TITLE
useStream and friends.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Provides the following methods:
 - `withOnMod(f: A => F[Unit])` - creates a new `ViewF` that chains the passed effect whenever `mod` (or `set`) is called.
 - `zoom` methods - creates a new `ViewF` focused on a part of `A`. This method can take either raw getter and setter functions or a `monocle` `Lens`, `Optional`, `Prism` or `Traversal`.
 - `as(iso: Iso[A, B])` - creates a new `ViewF[F, B]`.
-- `asOpt` - creates a new `ViewOptF[F, A]`.
-- `asList` - creates a new `ViewListF[F, A]`.
+- `asViewOpt` - creates a new `ViewOptF[F, A]`.
+- `asViewList` - creates a new `ViewListF[F, A]`.
 
 `ViewOptF[F, A]` and `ViewListF[F, A]` are variants that hold a value known to be an `Option[A]` or `List[A]` respectively. They are returned when `zoom`ing using `Optional`, `Prism` or `Traversal`.
 

--- a/js/src/main/scala/crystal/react/StreamRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererMod.scala
@@ -11,7 +11,7 @@ import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.util.Effect.UnsafeSync
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{ Ref => _, _ }
+import japgolly.scalajs.react.{Ref => _, _}
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.FiniteDuration

--- a/js/src/main/scala/crystal/react/StreamRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamRendererMod.scala
@@ -11,7 +11,7 @@ import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.util.Effect.UnsafeSync
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{Ref => _, _}
+import japgolly.scalajs.react.{ Ref => _, _ }
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.FiniteDuration

--- a/js/src/main/scala/crystal/react/StreamResourceRenderer.scala
+++ b/js/src/main/scala/crystal/react/StreamResourceRenderer.scala
@@ -1,5 +1,6 @@
 package crystal.react
 
+import react.common.ReactFnProps
 import cats.effect.kernel.Resource
 import crystal.Pot
 import crystal._
@@ -10,7 +11,6 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
 import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
-import _root_.react.common.ReactFnProps
 
 final case class StreamResourceRenderer[A](
   resource:           Resource[DefaultA, fs2.Stream[DefaultA, A]],

--- a/js/src/main/scala/crystal/react/StreamResourceRendererMod.scala
+++ b/js/src/main/scala/crystal/react/StreamResourceRendererMod.scala
@@ -1,5 +1,6 @@
 package crystal.react
 
+import react.common.ReactFnProps
 import cats.effect.Sync
 import cats.effect.kernel.Resource
 import cats.syntax.all._
@@ -14,10 +15,9 @@ import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import japgolly.scalajs.react.util.Effect.UnsafeSync
 import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
-import _root_.react.common.ReactFnProps
 
-import scala.reflect.ClassTag
 import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
 
 final case class StreamResourceRendererMod[A](
   resource:     Resource[DefaultA, fs2.Stream[DefaultA, A]],

--- a/js/src/main/scala/crystal/react/hooks/UseResource.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseResource.scala
@@ -8,7 +8,6 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.hooks.CustomHook
 import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
 
-// TODO Functional streamrender* components
 object UseResource {
   def hook[A] = CustomHook[Resource[DefaultA, A]]
     .useState(Pot.pending[A])
@@ -17,8 +16,7 @@ object UseResource {
         .flatMap { case (value, close) =>
           state.setStateAsync(value.ready).as(close)
         }
-        .handleErrorWith(t => state.setStateAsync(Pot.error(t)))
-        .as(DefaultA.delay(()))
+        .handleErrorWith(t => state.setStateAsync(Pot.error(t)).as(DefaultA.delay(())))
     )
     .buildReturning((_, state) => state.value)
 

--- a/js/src/main/scala/crystal/react/hooks/UseStateCallback.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStateCallback.scala
@@ -1,0 +1,72 @@
+package crystal.react.hooks
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.hooks.Hooks
+import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
+
+import scala.collection.immutable.Queue
+
+object UseStateCallback {
+  def hook[A] =
+    CustomHook[Hooks.UseState[A]]
+      .useRef(Queue.empty[A => DefaultS[Unit]])
+      // Credit to japgolly for this implementation; this is copied from StateSnapshot.
+      .useEffectBy { (state, delayedCallbacks) =>
+        val cbs = delayedCallbacks.value
+        if (cbs.isEmpty)
+          DefaultS.empty
+        else
+          delayedCallbacks.set(Queue.empty) >>
+            DefaultS.runAll(cbs.toList.map(_(state.value)): _*)
+      }
+      .buildReturning((_, delayedCallbacks) =>
+        (cb: A => DefaultS[Unit]) => delayedCallbacks.mod(_.enqueue(cb))
+      )
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      final def useStateCallback[A](state: => Hooks.UseState[A])(implicit
+        step:                              Step
+      ): step.Next[(A => DefaultS[Unit]) => DefaultS[Unit]] =
+        useStateCallbackBy(_ => state)
+
+      final def useStateCallbackBy[A](state: Ctx => Hooks.UseState[A])(implicit
+        step:                                Step
+      ): step.Next[(A => DefaultS[Unit]) => DefaultS[Unit]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(state(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      def useStateCallbackBy[A](state: CtxFn[Hooks.UseState[A]])(implicit
+        step:                          Step
+      ): step.Next[(A => DefaultS[Unit]) => DefaultS[Unit]] =
+        useStateCallbackBy(step.squash(state)(_))
+    }
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtDelayedCallback1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtDelayedCallback2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx,
+                                                                                         CtxFn
+    ]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/UseStateViewWithReuse.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStateViewWithReuse.scala
@@ -1,33 +1,17 @@
 package crystal.react.hooks
 
 import crystal.react.ReuseView
+import crystal.react.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.hooks.CustomHook
-import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 
-import scala.collection.immutable.Queue
 import scala.reflect.ClassTag
 
 object UseStateViewWithReuse {
   def hook[A: ClassTag: Reusability]: CustomHook[A, ReuseView[A]] =
     CustomHook[A]
-      .useStateBy(initialValue => initialValue)
-      .useRef(Queue.empty[A => DefaultS[Unit]])
-      // Credit to japgolly for this implementation; this is copied from StateSnapshot.
-      .useEffectBy { (_, state, delayedCallbacks) =>
-        val cbs = delayedCallbacks.value
-        if (cbs.isEmpty)
-          DefaultS.empty
-        else
-          delayedCallbacks.set(Queue.empty) >>
-            DefaultS.runAll(cbs.toList.map(_(state.value)): _*)
-      }
-      .buildReturning { (_, state, delayedCallbacks) =>
-        ReuseView[A](
-          state.value,
-          (f, cb) => state.modState(f) >> delayedCallbacks.mod(_.enqueue(cb))
-        )
-      }
+      .useStateViewBy(initialValue => initialValue)
+      .buildReturning((_, view) => view.reuseByValue)
 
   object HooksApiExt {
     sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {

--- a/js/src/main/scala/crystal/react/hooks/UseStream.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStream.scala
@@ -1,0 +1,58 @@
+package crystal.react.hooks
+
+import crystal.Pot
+import crystal.react.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
+object UseStream {
+  def hook[A] = CustomHook[fs2.Stream[DefaultA, A]]
+    .useState(Pot.pending[A])
+    .useResourceBy((stream, state) => streamEvaluationResource(stream, state.setStateAsync))
+    .buildReturning((_, state, _) => state.value)
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      final def useStream[A](stream: fs2.Stream[DefaultA, A])(implicit
+        step:                        Step
+      ): step.Next[Pot[A]] =
+        useStreamBy(_ => stream)
+
+      final def useStreamBy[A](stream: Ctx => fs2.Stream[DefaultA, A])(implicit
+        step:                          Step
+      ): step.Next[Pot[A]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(stream(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      def useStreamBy[A](stream: CtxFn[fs2.Stream[DefaultA, A]])(implicit
+        step:                    Step
+      ): step.Next[Pot[A]] =
+        useStreamBy(step.squash(stream)(_))
+    }
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtStream1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtStream2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/UseStreamResource.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStreamResource.scala
@@ -1,0 +1,67 @@
+package crystal.react.hooks
+
+import cats.effect.Resource
+import crystal.Pot
+import crystal.react.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
+object UseStreamResource {
+  def hook[A] = CustomHook[Resource[DefaultA, fs2.Stream[DefaultA, A]]]
+    .useState(Pot.pending[A])
+    .useResourceBy((streamResource, state) =>
+      streamResource.flatMap(stream => streamEvaluationResource(stream, state.setStateAsync))
+    )
+    .buildReturning((_, state, _) => state.value)
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      final def useStreamResource[A](streamResource: Resource[DefaultA, fs2.Stream[DefaultA, A]])(
+        implicit step:                               Step
+      ): step.Next[Pot[A]] =
+        useStreamResourceBy(_ => streamResource)
+
+      final def useStreamResourceBy[A](
+        streamResource: Ctx => Resource[DefaultA, fs2.Stream[DefaultA, A]]
+      )(implicit
+        step:           Step
+      ): step.Next[Pot[A]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(streamResource(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      def useStreamResourceBy[A](
+        streamResource: CtxFn[Resource[DefaultA, fs2.Stream[DefaultA, A]]]
+      )(implicit
+        step:           Step
+      ): step.Next[Pot[A]] =
+        useStreamResourceBy(step.squash(streamResource)(_))
+    }
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtStreamResource1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtStreamResource2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx,
+                                                                                        CtxFn
+    ]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/UseStreamResourceView.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStreamResourceView.scala
@@ -1,0 +1,76 @@
+package crystal.react.hooks
+
+import cats.effect.Resource
+import cats.syntax.all._
+import crystal.Pot
+import crystal.react.View
+import crystal.react.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
+
+object UseStreamResourceView {
+  def hook[A] =
+    CustomHook[Resource[DefaultA, fs2.Stream[DefaultA, A]]]
+      .useState(Pot.pending[A])
+      .useStateCallbackBy((_, state) => state)
+      .useResourceBy((streamResource, state, _) =>
+        streamResource.flatMap(stream => streamEvaluationResource(stream, state.setStateAsync))
+      )
+      .buildReturning { (_, state, delayedCallback, _) =>
+        state.value.map { a =>
+          View[A](
+            a,
+            (f: A => A, cb: A => DefaultS[Unit]) =>
+              state.modState(_.map(f)) >> delayedCallback(_.toOption.foldMap(cb))
+          )
+        }
+      }
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      final def useStreamResourceView[A](
+        streamResource: Resource[DefaultA, fs2.Stream[DefaultA, A]]
+      )(implicit step:  Step): step.Next[Pot[View[A]]] =
+        useStreamResourceViewBy(_ => streamResource)
+
+      final def useStreamResourceViewBy[A](
+        streamResource: Ctx => Resource[DefaultA, fs2.Stream[DefaultA, A]]
+      )(implicit step:  Step): step.Next[Pot[View[A]]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(streamResource(ctx))
+        }
+
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+      def useStreamResourceViewBy[A](
+        streamResource: CtxFn[Resource[DefaultA, fs2.Stream[DefaultA, A]]]
+      )(implicit step:  Step): step.Next[Pot[View[A]]] =
+        useStreamResourceViewBy(step.squash(streamResource)(_))
+    }
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtStreamResourceView1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtStreamResourceView2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx,
+                                                                                            CtxFn
+    ]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/UseStreamResourceViewWithReuse.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStreamResourceViewWithReuse.scala
@@ -1,0 +1,64 @@
+package crystal.react.hooks
+
+import cats.effect.Resource
+import crystal.Pot
+import crystal.react.ReuseView
+import crystal.react.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
+import scala.reflect.ClassTag
+
+object UseStreamResourceViewWithReuse {
+  def hook[A: ClassTag: Reusability] =
+    CustomHook[Resource[DefaultA, fs2.Stream[DefaultA, A]]]
+      .useStreamResourceViewBy(streamResource => streamResource)
+      .buildReturning((_, view) => view.map(_.reuseByValue))
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      final def useStreamResourceViewWithReuse[A: ClassTag: Reusability](
+        streamResource: Resource[DefaultA, fs2.Stream[DefaultA, A]]
+      )(implicit step:  Step): step.Next[Pot[ReuseView[A]]] =
+        useStreamResourceViewWithReuseBy(_ => streamResource)
+
+      final def useStreamResourceViewWithReuseBy[A: ClassTag: Reusability](
+        streamResource: Ctx => Resource[DefaultA, fs2.Stream[DefaultA, A]]
+      )(implicit step:  Step): step.Next[Pot[ReuseView[A]]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(streamResource(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      def useStreamResourceViewWithReuseBy[A: ClassTag: Reusability](
+        streamResource: CtxFn[Resource[DefaultA, fs2.Stream[DefaultA, A]]]
+      )(implicit step:  Step): step.Next[Pot[ReuseView[A]]] =
+        useStreamResourceViewWithReuseBy(step.squash(streamResource)(_))
+    }
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtStreamResourceViewWithReuse1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtStreamResourceViewWithReuse2[Ctx, CtxFn[
+      _
+    ], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/UseStreamView.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStreamView.scala
@@ -1,0 +1,60 @@
+package crystal.react.hooks
+
+import cats.effect.kernel.Resource
+import crystal.Pot
+import crystal.react.View
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
+object UseStreamView {
+  def hook[A] =
+    CustomHook[fs2.Stream[DefaultA, A]]
+      .useStreamResourceViewBy(stream => Resource.pure(stream))
+      .buildReturning((_, view) => view)
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      final def useStreamView[A](stream: fs2.Stream[DefaultA, A])(implicit
+        step:                            Step
+      ): step.Next[Pot[View[A]]] =
+        useStreamViewBy(_ => stream)
+
+      final def useStreamViewBy[A](stream: Ctx => fs2.Stream[DefaultA, A])(implicit
+        step:                              Step
+      ): step.Next[Pot[View[A]]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(stream(ctx))
+        }
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      def useStreamViewBy[A](stream: CtxFn[fs2.Stream[DefaultA, A]])(implicit
+        step:                        Step
+      ): step.Next[Pot[View[A]]] =
+        useStreamViewBy(step.squash(stream)(_))
+    }
+
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtStreamView1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtStreamView2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/UseStreamViewWithReuse.scala
+++ b/js/src/main/scala/crystal/react/hooks/UseStreamViewWithReuse.scala
@@ -1,0 +1,64 @@
+package crystal.react.hooks
+
+import crystal.Pot
+import crystal.react.ReuseView
+import crystal.react.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.hooks.CustomHook
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+
+import scala.reflect.ClassTag
+
+object UseStreamViewWithReuse {
+  def hook[A: ClassTag: Reusability] =
+    CustomHook[fs2.Stream[DefaultA, A]]
+      .useStreamViewBy(props => props)
+      .buildReturning((_, view) => view.map(_.reuseByValue))
+
+  object HooksApiExt {
+    sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+      final def useStreamViewWithReuse[A: ClassTag: Reusability](stream: fs2.Stream[DefaultA, A])(
+        implicit step:                                                   Step
+      ): step.Next[Pot[ReuseView[A]]] =
+        useStreamViewWithReuseBy(_ => stream)
+
+      final def useStreamViewWithReuseBy[A: ClassTag: Reusability](
+        stream:        Ctx => fs2.Stream[DefaultA, A]
+      )(implicit step: Step): step.Next[Pot[ReuseView[A]]] =
+        api.customBy { ctx =>
+          val hookInstance = hook[A]
+          hookInstance(stream(ctx))
+        }
+
+    }
+
+    final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ) extends Primary[Ctx, Step](api) {
+
+      def useStreamViewWithReuseBy[A: ClassTag: Reusability](
+        stream:        CtxFn[fs2.Stream[DefaultA, A]]
+      )(implicit step: Step): step.Next[Pot[ReuseView[A]]] =
+        useStreamViewWithReuseBy(step.squash(stream)(_))
+    }
+  }
+
+  trait HooksApiExt {
+    import HooksApiExt._
+
+    implicit def hooksExtStreamViewWithReuse1[Ctx, Step <: HooksApi.AbstractStep](
+      api: HooksApi.Primary[Ctx, Step]
+    ): Primary[Ctx, Step] =
+      new Primary(api)
+
+    implicit def hooksExtStreamViewWithReuse2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx,
+                                                                                             CtxFn
+    ]](
+      api: HooksApi.Secondary[Ctx, CtxFn, Step]
+    ): Secondary[Ctx, CtxFn, Step] =
+      new Secondary(api)
+  }
+
+  object implicits extends HooksApiExt
+}

--- a/js/src/main/scala/crystal/react/hooks/package.scala
+++ b/js/src/main/scala/crystal/react/hooks/package.scala
@@ -1,15 +1,41 @@
 package crystal.react
 
 import cats.effect.Fiber
+import cats.effect.FiberIO
+import cats.effect.Resource
+import crystal.Pot
+import crystal.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
 
 package object hooks
     extends UseSingleEffect.HooksApiExt
     with UseSerialState.HooksApiExt
+    with UseStateCallback.HooksApiExt
     with UseStateView.HooksApiExt
     with UseStateViewWithReuse.HooksApiExt
     with UseSerialStateView.HooksApiExt
     with UseAsyncEffect.HooksApiExt
     with UseAsyncEffectOnMount.HooksApiExt
-    with UseResource.HooksApiExt {
+    with UseResource.HooksApiExt
+    with UseStream.HooksApiExt
+    with UseStreamResource.HooksApiExt
+    with UseStreamView.HooksApiExt
+    with UseStreamResourceView.HooksApiExt
+    with UseStreamViewWithReuse.HooksApiExt
+    with UseStreamResourceViewWithReuse.HooksApiExt {
   type UseSingleEffectLatch[F[_]] = Fiber[F, Throwable, Unit]
+
+  protected[hooks] def streamEvaluationResource[A](
+    stream: fs2.Stream[DefaultA, A],
+    setPot: Pot[A] => DefaultA[Unit]
+  ): Resource[DefaultA, FiberIO[Unit]] =
+    Resource.make(
+      stream
+        .evalMap(setPot.compose(_.ready))
+        .compile
+        .drain
+        .handleErrorWith(setPot.compose(Pot.error))
+        .start
+    )(_.cancel)
 }

--- a/js/src/main/scala/crystal/react/implicits/package.scala
+++ b/js/src/main/scala/crystal/react/implicits/package.scala
@@ -1,5 +1,6 @@
 package crystal.react
 
+import cats.Monad
 import cats.MonadError
 import cats.effect.Async
 import cats.effect.Sync
@@ -18,7 +19,6 @@ import org.typelevel.log4cats.Logger
 
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
-import cats.Monad
 
 package object implicits {
   implicit class DefaultSToOps[A](private val self: DefaultS[A])(implicit
@@ -307,7 +307,7 @@ package object implicits {
     def toViewOpt: ViewOptF[F, A] =
       optView.fold(new ViewOptF[F, A](none, (_, cb) => cb(none)) {
         override def modAndGet(f: A => A)(implicit F: Async[F]): F[Option[A]] = none.pure[F]
-      })(_.asOpt)
+      })(_.asViewOpt)
   }
 
   implicit class ReuseViewDefaultSOps[A](private val view: ReuseView[A]) {

--- a/js/src/main/scala/crystal/react/reuse/package.scala
+++ b/js/src/main/scala/crystal/react/reuse/package.scala
@@ -310,7 +310,7 @@ package object reuse extends ReuseImplicitsLowPriority {
 
     def as[B](iso: Iso[A, B]): Reuse[ViewF[F, B]] = zoom(iso.asLens)
 
-    def asOpt: Reuse[ViewOptF[F, A]] = zoom(Iso.id[A].asOptional)
+    def asViewOpt: Reuse[ViewOptF[F, A]] = zoom(Iso.id[A].asOptional)
 
     def asList: Reuse[ViewListF[F, A]] = zoom(Iso.id[A].asTraversal)
 

--- a/shared/src/main/scala/crystal/viewF.scala
+++ b/shared/src/main/scala/crystal/viewF.scala
@@ -73,9 +73,9 @@ final class ViewF[F[_]: Monad, A](val get: A, val modCB: ((A => A), A => F[Unit]
 
   def as[B](iso: Iso[A, B]): ViewF[F, B] = zoom(iso.asLens)
 
-  def asOpt: ViewOptF[F, A] = zoom(Iso.id[A].asOptional)
+  def asViewOpt: ViewOptF[F, A] = zoom(Iso.id[A].asOptional)
 
-  def asList: ViewListF[F, A] = zoom(Iso.id[A].asTraversal)
+  def asViewList: ViewListF[F, A] = zoom(Iso.id[A].asTraversal)
 
   def zoom[B](lens: Lens[A, B]): ViewF[F, B] =
     zoom(lens.get _)(lens.modify)
@@ -120,7 +120,9 @@ abstract class ViewOptF[F[_]: Monad, A](
 ) extends ViewOps[F, Option, A] { self =>
   def as[B](iso: Iso[A, B]): ViewOptF[F, B] = zoom(iso.asLens)
 
-  def asList: ViewListF[F, A] = zoom(Iso.id[A].asTraversal)
+  def asViewList: ViewListF[F, A] = zoom(Iso.id[A].asTraversal)
+
+  def asView(implicit ev: Monoid[F[Unit]]): Option[ViewF[F, A]] = mapValue(identity)
 
   def zoom[B](getB: A => B)(modB: (B => B) => A => A): ViewOptF[F, B] =
     new ViewOptF(

--- a/shared/src/test/scala/crystal/ViewFSpec.scala
+++ b/shared/src/test/scala/crystal/ViewFSpec.scala
@@ -104,28 +104,28 @@ class ViewFSpec extends munit.CatsEffectSuite {
     } yield assert(get === 1))
   }
 
-  test("ViewF[Wrap[Int]].asOpt.zoom(Lens).mod") {
+  test("ViewF[Wrap[Int]].asViewOpt.zoom(Lens).mod") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, refModCB(ref)).asOpt.zoom(lens)
+      view = ViewF(wrappedValue, refModCB(ref)).asViewOpt.zoom(lens)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
   }
 
-  test("ViewF[Wrap[Int]].asOpt.zoom(Lens).set") {
+  test("ViewF[Wrap[Int]].asViewOpt.zoom(Lens).set") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, refModCB(ref)).asOpt.zoom(lens)
+      view = ViewF(wrappedValue, refModCB(ref)).asViewOpt.zoom(lens)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
   }
 
-  test("ViewF[Wrap[Int]].asOpt.zoom(Lens).modAndGet") {
+  test("ViewF[Wrap[Int]].asViewOpt.zoom(Lens).modAndGet") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, refModCB(ref)).asOpt.zoom(lens)
+      view = ViewF(wrappedValue, refModCB(ref)).asViewOpt.zoom(lens)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === 1.some))
   }
@@ -133,7 +133,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asList.zoom(Lens).mod") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, refModCB(ref)).asList.zoom(lens)
+      view = ViewF(wrappedValue, refModCB(ref)).asViewList.zoom(lens)
       _   <- view.mod(_ + 1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -142,7 +142,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asList.zoom(Lens).set") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, refModCB(ref)).asList.zoom(lens)
+      view = ViewF(wrappedValue, refModCB(ref)).asViewList.zoom(lens)
       _   <- view.set(1)
       get <- ref.get
     } yield assert(get === Wrap(1)))
@@ -151,7 +151,7 @@ class ViewFSpec extends munit.CatsEffectSuite {
   test("ViewF[Wrap[Int]].asList.zoom(Lens).modAndGet") {
     (for {
       ref <- Ref[IO].of(wrappedValue)
-      view = ViewF(wrappedValue, refModCB(ref)).asList.zoom(lens)
+      view = ViewF(wrappedValue, refModCB(ref)).asViewList.zoom(lens)
       get <- view.modAndGet(_ + 1)
     } yield assert(get === List(1)))
   }

--- a/shared/src/test/scala/crystal/ViewOptFSpec.scala
+++ b/shared/src/test/scala/crystal/ViewOptFSpec.scala
@@ -83,7 +83,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).asList.mod") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, refModCB(ref)).zoom(some[Wrap[Int]]).asList
+      view = ViewF(valueOpt, refModCB(ref)).zoom(some[Wrap[Int]]).asViewList
       _   <- view.mod(_.map(_ + 1))
       get <- ref.get
     } yield assert(get === Wrap(1).some))
@@ -92,7 +92,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).asList.set") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, refModCB(ref)).zoom(some[Wrap[Int]]).asList
+      view = ViewF(valueOpt, refModCB(ref)).zoom(some[Wrap[Int]]).asViewList
       _   <- view.set(Wrap(1))
       get <- ref.get
     } yield assert(get === Wrap(1).some))
@@ -101,7 +101,7 @@ class ViewOptFSpec extends munit.CatsEffectSuite {
   test("ViewF[Option[Wrap[Int]]].zoom(some).asList.modAndGet") {
     (for {
       ref <- Ref[IO].of(valueOpt)
-      view = ViewF(valueOpt, refModCB(ref)).zoom(some[Wrap[Int]]).asList
+      view = ViewF(valueOpt, refModCB(ref)).zoom(some[Wrap[Int]]).asViewList
       get <- view.modAndGet(_.map(_ + 1))
     } yield assert(get === List(Wrap(1))))
   }


### PR DESCRIPTION
This PR introduces a set of hooks that will allow us to greatly simplify code in UI that uses streams and stream resources, effectively deprecating `StreamRender(Mod)` and `StreamResourceRender(Mod)`.

The new hooks are:
- `useStateCallback`: allows defining callbacks when state is changed or modified, which was possible in class components but not out of the box for functional components.
- `useStream[A]`: provides values from a `fs2.Stream[DefaultA, A]`. The fiber evaluating the stream is cancelled on unmount. Values as provided as `Pot[A]`.
- `useStreamView`: same as `useStream` but provides a `View[A]` so that the value can also be changed locally.
- `useStreamViewWithReuse`: same as `useStreamView` but provides a `ReuseView[A]`.
- `useStreamResource`: as `useStream` but receives a `Resource[DefaultA, fs2.Stream[DefaultA, A]]`. Besides cancelling the stream evaluating fiber, the resource is also closed on unmount.
- `useStreamResourceView`: same as `useStreamResource` but provides a `View[A]` so that the value can also be changed locally.
- `useStreamResourceViewWithReuse`: same as `useStreamResourceView` but provides a `ReuseView[A]`.