### PR TITLE
Avoid name duplication

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ inThisBuild(
     // implicit resolution for Reuse[View] does not work properly in scala 3. When we
     // switch to scala 3, we can use an opaque type ReuseViewF instead of extension
     // methods on Reuse[ViewF], etc.
-    crossScalaVersions                             := Seq("2.13.8", "3.1.2"),
+    crossScalaVersions                             := Seq("2.13.8", "3.1.3"),
     organization                                   := "com.rpiaggio",
     homepage                                       := Some(url("https://github.com/rpiaggio/crystal")),
     licenses += ("BSD 3-Clause", url(

--- a/js/src/main/scala/crystal/react/reuse/package.scala
+++ b/js/src/main/scala/crystal/react/reuse/package.scala
@@ -293,7 +293,7 @@ package object reuse extends ReuseImplicitsLowPriority {
     ): Reuse[B] = Reuse.currying(r, s, t, u, v).in(fn)
   }
 
-  implicit class ReuseViewF[F[_]: Monad, A](val rv: Reuse[ViewF[F, A]]) {
+  implicit class ReuseViewFOps[F[_]: Monad, A](val rv: Reuse[ViewF[F, A]]) {
     val get: A                                           = rv.value.get
     val modCB: ((A => A), A => F[Unit]) => F[Unit]       = rv.value.modCB
     def modAndGet(f: A => A)(implicit F: Async[F]): F[A] = rv.value.modAndGet(f)
@@ -341,7 +341,7 @@ package object reuse extends ReuseImplicitsLowPriority {
       get.map(a => f(zoom(_ => a)(f => a1 => ev.flip(a1.map(f)))))
   }
 
-  implicit class ReuseViewOptF[F[_]: Monad, A](val rvo: Reuse[ViewOptF[F, A]]) {
+  implicit class ReuseViewOptFOps[F[_]: Monad, A](val rvo: Reuse[ViewOptF[F, A]]) {
     val get: Option[A]                                           = rvo.value.get
     val modCB: ((A => A), Option[A] => F[Unit]) => F[Unit]       = rvo.value.modCB
     def modAndGet(f: A => A)(implicit F: Async[F]): F[Option[A]] = rvo.value.modAndGet(f)
@@ -379,7 +379,7 @@ package object reuse extends ReuseImplicitsLowPriority {
       get.map(a => f(rvo.map(_ => ViewF[F, A](a, (mod, cb) => modCB(mod, _.foldMap(cb))))))
   }
 
-  implicit class ReuseViewListF[F[_]: Monad, A](val rvl: Reuse[ViewListF[F, A]]) {
+  implicit class ReuseViewListFOps[F[_]: Monad, A](val rvl: Reuse[ViewListF[F, A]]) {
     val get: List[A]                                           = rvl.value.get
     val modCB: ((A => A), List[A] => F[Unit]) => F[Unit]       = rvl.value.modCB
     def modAndGet(f: A => A)(implicit F: Async[F]): F[List[A]] = rvl.value.modAndGet(f)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,7 +15,7 @@ object Settings {
     val mUnit           = "0.7.29"
     val mUnitCatsEffect = "1.0.7"
     val reactCommon     = "0.17.0"
-    val lucumaReact     = "1.0-68a9512-SNAPSHOT"
+    val lucumaReact     = "1.0-2f1c8d8-SNAPSHOT"
     val scalajsReact    = "2.1.1"
   }
 


### PR DESCRIPTION
There are implicit classes `ReuseViewF` etc as well as a type alias `ReuseViewF`. That seems to create conflicts at least on scala 3