### PR TITLE
PotOption

### DIFF
--- a/js/src/main/scala/crystal/react/hooks/package.scala
+++ b/js/src/main/scala/crystal/react/hooks/package.scala
@@ -28,15 +28,4 @@ package object hooks
 
 package hooks {
   protected[hooks] final case class WithDeps[D, A](deps: D, fromDeps: D => A)
-
-  final case class SyncValue[A](value: A, awaitOpt: Reusable[Option[DefaultA[Unit]]]) {
-    def map[B](f: A => B): SyncValue[B] =
-      SyncValue(f(value), awaitOpt)
-  }
-
-  object SyncValue {
-    implicit def reuseSyncValue[A: Reusability]: Reusability[SyncValue[A]] =
-      Reusability.by(x => (x.value, x.awaitOpt))
-  }
-
 }

--- a/shared/src/main/scala/crystal/ActionInterpreter.scala
+++ b/shared/src/main/scala/crystal/ActionInterpreter.scala
@@ -1,9 +1,0 @@
-package crystal
-
-trait ActionInterpreterOpt[F[_], A[_[_]], T] {
-  def of(view: ViewOptF[F, T]): A[F]
-}
-
-trait ActionInterpreter[F[_], A[_[_]], T] {
-  def of(view: ViewF[F, T]): A[F]
-}

--- a/shared/src/main/scala/crystal/Pot.scala
+++ b/shared/src/main/scala/crystal/Pot.scala
@@ -1,6 +1,7 @@
 package crystal
 
 import cats.syntax.all._
+import crystal.implicits._
 import monocle.Prism
 
 import scala.util.Failure
@@ -10,64 +11,69 @@ import scala.util.Try
 sealed trait Pot[+A] {
   def map[B](f: A => B): Pot[B] =
     this match {
-      case pend @ Pending(_) => pend.valueCast[B]
-      case err @ Error(_)    => err.valueCast[B]
-      case Ready(a)          => Ready(f(a))
+      case Pot.Pending        => Pot.Pending
+      case err @ Pot.Error(_) => err.valueCast[B]
+      case Pot.Ready(a)       => Pot.Ready(f(a))
     }
 
-  def fold[B](fp: Long => B, fe: Throwable => B, fr: A => B): B =
+  def fold[B](fp: => B, fe: Throwable => B, fr: A => B): B =
     this match {
-      case Pending(start) => fp(start)
-      case Error(t)       => fe(t)
-      case Ready(a)       => fr(a)
+      case Pot.Pending  => fp
+      case Pot.Error(t) => fe(t)
+      case Pot.Ready(a) => fr(a)
     }
 
-  def isReady: Boolean = fold(_ => false, _ => false, _ => true)
+  def isReady: Boolean = fold(false, _ => false, _ => true)
 
-  def isPending: Boolean = fold(_ => true, _ => false, _ => false)
+  def isPending: Boolean = fold(true, _ => false, _ => false)
 
-  def isError: Boolean = fold(_ => false, _ => true, _ => false)
+  def isError: Boolean = fold(false, _ => true, _ => false)
 
   def flatten[B](implicit ev: A <:< Pot[B]): Pot[B] =
     this match {
-      case pend @ Pending(_) => pend.valueCast[B]
-      case err @ Error(_)    => err.valueCast[B]
-      case Ready(a)          => a
+      case Pot.Pending        => Pot.Pending
+      case err @ Pot.Error(_) => err.valueCast[B]
+      case Pot.Ready(potB)    => potB
     }
 
   def flatMap[B](f: A => Pot[B]): Pot[B] =
     map(f).flatten
 
-  def toOption: Option[A] = fold(_ => none, _ => none, _.some)
+  def void: Pot[Unit] = map(_ => ())
 
-  def toTryOption: Option[Try[A]] =
+  def toPotOption: PotOption[A] =
+    fold(PotOption.Pending, PotOption.Error.apply, _.readySome)
+
+  def toOption: Option[A] = fold(none, _ => none, _.some)
+
+  def toOptionTry: Option[Try[A]] =
     this match {
-      case Pending(_) => none
-      case Error(t)   => Failure(t).some
-      case Ready(a)   => Success(a).some
+      case Pot.Pending  => none
+      case Pot.Error(t) => Failure(t).some
+      case Pot.Ready(a) => Success(a).some
     }
-
 }
-
-final case class Pending(start: Long = System.currentTimeMillis()) extends Pot[Nothing] {
-  def valueCast[B]: Pot[B] = asInstanceOf[Pot[B]]
-}
-final case class Error(t: Throwable)                               extends Pot[Nothing] {
-  def valueCast[B]: Pot[B] = asInstanceOf[Pot[B]]
-}
-final case class Ready[+A](value: A)                               extends Pot[A]
 
 object Pot {
+  case object Pending                  extends Pot[Nothing]
+  final case class Error(t: Throwable) extends Pot[Nothing] {
+    def valueCast[B]: Pot[B] = asInstanceOf[Pot[B]]
+  }
+  final case class Ready[+A](value: A) extends Pot[A]
+
   def apply[A](a: A): Pot[A] = Ready(a)
 
-  def pending[A]: Pot[A] = Pending()
+  def pending[A]: Pot[A] = Pending
 
   def error[A](t: Throwable): Pot[A] = Error(t)
+
+  def fromOption[A](po: PotOption[A]): Pot[A] =
+    po.toPot
 
   def fromOption[A](opt: Option[A]): Pot[A] =
     opt match {
       case Some(a) => Ready(a)
-      case None    => Pending()
+      case None    => Pending
     }
 
   def fromTry[A](tr: Try[A]): Pot[A] =
@@ -76,22 +82,17 @@ object Pot {
       case Failure(t) => Error(t)
     }
 
-  def fromTryOption[A](trOpt: Option[Try[A]]): Pot[A] =
+  def fromOptionTry[A](trOpt: Option[Try[A]]): Pot[A] =
     trOpt match {
       case Some(Success(a)) => Ready(a)
       case Some(Failure(t)) => Error(t)
-      case None             => Pending()
+      case None             => Pending
     }
 
   def readyPrism[A]: Prism[Pot[A], A] = Prism[Pot[A], A] {
     case Ready(a) => a.some
     case _        => none
   }(apply)
-
-  def pendingPrism[A]: Prism[Pot[A], Long] = Prism[Pot[A], Long] {
-    case Pending(start) => start.some
-    case _              => none
-  }(Pending(_))
 
   def errorPrism[A]: Prism[Pot[A], Throwable] = Prism[Pot[A], Throwable] {
     case Error(t) => t.some

--- a/shared/src/main/scala/crystal/PotOption.scala
+++ b/shared/src/main/scala/crystal/PotOption.scala
@@ -1,0 +1,111 @@
+package crystal
+
+import cats.syntax.all._
+import monocle.Prism
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+sealed trait PotOption[+A] {
+  def map[B](f: A => B): PotOption[B] =
+    this match {
+      case PotOption.Pending        => PotOption.Pending
+      case err @ PotOption.Error(_) => err.valueCast[B]
+      case PotOption.ReadyNone      => PotOption.ReadyNone
+      case PotOption.ReadySome(a)   => PotOption.ReadySome(f(a))
+    }
+
+  def fold[B](fp: => B, fe: Throwable => B, frn: => B, frs: A => B): B =
+    this match {
+      case PotOption.Pending      => fp
+      case PotOption.Error(t)     => fe(t)
+      case PotOption.ReadyNone    => frn
+      case PotOption.ReadySome(a) => frs(a)
+    }
+
+  def isReady: Boolean = fold(false, _ => false, true, _ => true)
+
+  def isDefined: Boolean = fold(false, _ => false, false, _ => true)
+
+  def isPending: Boolean = fold(true, _ => false, false, _ => false)
+
+  def isError: Boolean = fold(false, _ => true, false, _ => false)
+
+  def flatten[B](implicit ev: A <:< PotOption[B]): PotOption[B] =
+    this match {
+      case PotOption.Pending         => PotOption.Pending
+      case err @ PotOption.Error(_)  => err.valueCast[B]
+      case PotOption.ReadyNone       => PotOption.ReadyNone
+      case PotOption.ReadySome(potB) => potB
+    }
+
+  def flatMap[B](f: A => PotOption[B]): PotOption[B] =
+    map(f).flatten
+
+  def void: PotOption[Unit] = map(_ => ())
+
+  def toPot: Pot[A] = fold(Pot.Pending, Pot.Error.apply, Pot.Pending, Pot.apply)
+
+  def toOption: Option[A] = fold(none, _ => none, none, _.some)
+
+  def toOptionTry: Option[Try[A]] =
+    toPot.toOptionTry
+}
+
+object PotOption {
+  case object Pending                      extends PotOption[Nothing]
+  final case class Error(t: Throwable)     extends PotOption[Nothing] {
+    def valueCast[B]: PotOption[B] = asInstanceOf[PotOption[B]]
+  }
+  case object ReadyNone                    extends PotOption[Nothing]
+  final case class ReadySome[+A](value: A) extends PotOption[A]
+
+  def apply[A](a: A): PotOption[A] = ReadySome(a)
+
+  def pending[A]: PotOption[A] = Pending
+
+  def error[A](t: Throwable): PotOption[A] = Error(t)
+
+  def readyNone[A]: PotOption[A] = ReadyNone
+
+  def fromPot[A](pot: Pot[A]): PotOption[A] =
+    pot.toPotOption
+
+  def fromOption[A](opt: Option[A]): PotOption[A] =
+    opt match {
+      case Some(a) => ReadySome(a)
+      case None    => ReadyNone
+    }
+
+  def fromTry[A](tr: Try[A]): PotOption[A] =
+    tr match {
+      case Success(a) => ReadySome(a)
+      case Failure(t) => Error(t)
+    }
+
+  def fromOptionTry[A](optTry: Option[Try[A]]): PotOption[A] =
+    optTry match {
+      case Some(Success(a)) => ReadySome(a)
+      case Some(Failure(t)) => Error(t)
+      case None             => Pending
+    }
+
+  def fromTryOption[A](trOpt: Try[Option[A]]): PotOption[A] =
+    trOpt match {
+      case Success(Some(a)) => ReadySome(a)
+      case Success(None)    => ReadyNone
+      case Failure(t)       => Error(t)
+    }
+
+  def readySomePrism[A]: Prism[PotOption[A], A] = Prism[PotOption[A], A] {
+    case ReadySome(a) => a.some
+    case _            => none
+  }(apply)
+
+  def errorPrism[A]: Prism[PotOption[A], Throwable] = Prism[PotOption[A], Throwable] {
+    case Error(t) => t.some
+    case _        => none
+  }(Error(_))
+
+}

--- a/shared/src/main/scala/crystal/implicits/package.scala
+++ b/shared/src/main/scala/crystal/implicits/package.scala
@@ -33,39 +33,62 @@ package object implicits {
   }
 
   implicit final class AnyToPotOps[A](private val a: A) extends AnyVal {
-    def ready: Pot[A] = Ready(a)
+    def ready: Pot[A] = Pot.Ready(a)
+
+    def readySome: PotOption[A] = PotOption.ReadySome(a)
   }
 
   implicit final class AnyOptionToPotOps[A](private val a: Option[A]) extends AnyVal {
     def toPot: Pot[A] = Pot.fromOption(a)
+
+    def toPotOption: PotOption[A] = PotOption.fromOption(a)
   }
 
   implicit final class TryOptionToPotOps[A](private val a: Option[Try[A]]) extends AnyVal {
-    def toPot: Pot[A] = Pot.fromTryOption(a)
+    def toPot: Pot[A] = Pot.fromOptionTry(a)
+
+    def toPotOption: PotOption[A] = PotOption.fromOptionTry(a)
   }
 
-  implicit final class TryToPotOps[A](private val a: Try[A]) /* extends AnyVal */ {
+  implicit final class TryToPotOps[A](private val a: Try[A]) extends AnyVal {
     def toPot: Pot[A] = Pot.fromTry[A](a)
+
+    def toPotOption: PotOption[A] = PotOption.fromTry(a)
   }
 
-  implicit def potEq[A: Eq](implicit eqThrowable: Eq[Throwable]): Eq[Pot[A]] =
+  implicit val eqPotNothing: Eq[Pot[Nothing]] =
+    new Eq[Pot[Nothing]] {
+      import throwable._
+
+      def eqv(x: Pot[Nothing], y: Pot[Nothing]): Boolean =
+        x match {
+          case Pot.Pending   =>
+            y match {
+              case Pot.Pending => true
+              case _           => false
+            }
+          case Pot.Error(tx) =>
+            y match {
+              case Pot.Error(ty) => tx === ty
+              case _             => false
+            }
+          case _             => false
+        }
+    }
+
+  implicit def eqPot[A: Eq]: Eq[Pot[A]] =
     new Eq[Pot[A]] {
       def eqv(x: Pot[A], y: Pot[A]): Boolean =
         x match {
-          case Pending(startx) =>
+          case Pot.Ready(ax) =>
             y match {
-              case Pending(starty) => startx === starty
-              case _               => false
+              case Pot.Ready(ay) => ax === ay
+              case _             => false
             }
-          case Error(tx)       =>
+          case _             =>
             y match {
-              case Error(ty) => tx === ty
-              case _         => false
-            }
-          case Ready(ax)       =>
-            y match {
-              case Ready(ay) => ax === ay
-              case _         => false
+              case Pot.Ready(_) => false
+              case _            => eqPotNothing.eqv(x.asInstanceOf[Pot[Nothing]], y.asInstanceOf[Pot[Nothing]])
             }
         }
     }
@@ -77,44 +100,44 @@ package object implicits {
     @tailrec
     override def tailRecM[A, B](a: A)(f: A => Pot[Either[A, B]]): Pot[B] =
       f(a) match {
-        case pend @ Pending(_) => pend.valueCast[B]
-        case err @ Error(_)    => err.valueCast[B]
-        case Ready(Left(a))    => tailRecM(a)(f)
-        case Ready(Right(b))   => Ready(b)
+        case Pot.Pending         => Pot.Pending
+        case err @ Pot.Error(_)  => err.valueCast[B]
+        case Pot.Ready(Left(a))  => tailRecM(a)(f)
+        case Pot.Ready(Right(b)) => Pot.Ready(b)
       }
 
     override def flatMap[A, B](fa: Pot[A])(f: A => Pot[B]): Pot[B] =
       fa.flatMap(f)
 
-    override def raiseError[A](t: Throwable): Pot[A] = Error(t)
+    override def raiseError[A](t: Throwable): Pot[A] = Pot.Error(t)
 
     override def handleErrorWith[A](fa: Pot[A])(f: Throwable => Pot[A]): Pot[A] =
       fa match {
-        case Error(t) => f(t)
-        case _        => fa
+        case Pot.Error(t) => f(t)
+        case _            => fa
       }
 
     override def traverse[F[_], A, B](
       fa: Pot[A]
     )(f:  A => F[B])(implicit F: Applicative[F]): F[Pot[B]] =
       fa match {
-        case pend @ Pending(_) => F.pure(pend.valueCast[B])
-        case err @ Error(_)    => F.pure(err.valueCast[B])
-        case Ready(a)          => F.map(f(a))(Ready(_))
+        case Pot.Pending        => F.pure(Pot.Pending)
+        case err @ Pot.Error(_) => F.pure(err.valueCast[B])
+        case Pot.Ready(a)       => F.map(f(a))(Pot.Ready(_))
       }
 
     override def foldLeft[A, B](fa: Pot[A], b: B)(f: (B, A) => B): B =
       fa match {
-        case Pending(_) => b
-        case Error(_)   => b
-        case Ready(a)   => f(b, a)
+        case Pot.Pending  => b
+        case Pot.Error(_) => b
+        case Pot.Ready(a) => f(b, a)
       }
 
     override def foldRight[A, B](fa: Pot[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
       fa match {
-        case Pending(_) => lb
-        case Error(_)   => lb
-        case Ready(a)   => f(a, lb)
+        case Pot.Pending  => lb
+        case Pot.Error(_) => lb
+        case Pot.Ready(a) => f(a, lb)
       }
 
     override def functor: Functor[Pot] = this
@@ -124,23 +147,159 @@ package object implicits {
 
     override def alignWith[A, B, C](fa: Pot[A], fb: Pot[B])(f: Ior[A, B] => C): Pot[C] =
       fa match {
-        case pend @ Pending(starta) =>
+        case Pot.Pending         =>
           fb match {
-            case Pending(startb) => Pending(math.min(starta, startb))
-            case Error(_)        => pend.valueCast[C]
-            case Ready(b)        => Ready(f(Ior.right(b)))
+            case Pot.Pending         => Pot.Pending
+            case errb @ Pot.Error(_) => errb.valueCast[C]
+            case Pot.Ready(b)        => Pot.Ready(f(Ior.right(b)))
           }
-        case err @ Error(_)         =>
+        case erra @ Pot.Error(_) =>
           fb match {
-            case pend @ Pending(_) => pend.valueCast[C]
-            case Error(_)          => err.valueCast[C]
-            case Ready(b)          => Ready(f(Ior.right(b)))
+            case Pot.Ready(b) => Pot.Ready(f(Ior.right(b)))
+            case _            => erra.valueCast[C]
           }
-        case Ready(a)               =>
+        case Pot.Ready(a)        =>
           fb match {
-            case Pending(_) => Ready(f(Ior.left(a)))
-            case Error(_)   => Ready(f(Ior.left(a)))
-            case Ready(b)   => Ready(f(Ior.both(a, b)))
+            case Pot.Ready(b) => Pot.Ready(f(Ior.both(a, b)))
+            case _            => Pot.Ready(f(Ior.left(a)))
+          }
+      }
+  }
+
+  implicit val eqPotOptionNothing: Eq[PotOption[Nothing]] =
+    new Eq[PotOption[Nothing]] {
+      import throwable._
+
+      def eqv(x: PotOption[Nothing], y: PotOption[Nothing]): Boolean =
+        x match {
+          case PotOption.Pending   =>
+            y match {
+              case PotOption.Pending => true
+              case _                 => false
+            }
+          case PotOption.Error(tx) =>
+            y match {
+              case PotOption.Error(ty) => tx === ty
+              case _                   => false
+            }
+          case PotOption.ReadyNone =>
+            y match {
+              case PotOption.ReadyNone => true
+              case _                   => false
+            }
+
+          case _ => false
+        }
+    }
+
+  implicit def eqPotOption[A: Eq]: Eq[PotOption[A]] =
+    new Eq[PotOption[A]] {
+      def eqv(x: PotOption[A], y: PotOption[A]): Boolean =
+        x match {
+          case PotOption.ReadySome(ax) =>
+            y match {
+              case PotOption.ReadySome(ay) => ax === ay
+              case _                       => false
+            }
+          case _                       =>
+            y match {
+              case PotOption.ReadySome(_) => false
+              case _                      =>
+                eqPotOptionNothing.eqv(
+                  x.asInstanceOf[PotOption[Nothing]],
+                  y.asInstanceOf[PotOption[Nothing]]
+                )
+            }
+        }
+    }
+
+  implicit object PotOptionCats
+      extends MonadError[PotOption, Throwable]
+      with Traverse[PotOption]
+      with Align[PotOption] {
+
+    override def pure[A](a: A): PotOption[A] = PotOption(a)
+
+    @tailrec
+    override def tailRecM[A, B](a: A)(f: A => PotOption[Either[A, B]]): PotOption[B] =
+      f(a) match {
+        case PotOption.Pending             => PotOption.Pending
+        case err @ PotOption.Error(_)      => err.valueCast[B]
+        case PotOption.ReadyNone           => PotOption.ReadyNone
+        case PotOption.ReadySome(Left(a))  => tailRecM(a)(f)
+        case PotOption.ReadySome(Right(b)) => PotOption.ReadySome(b)
+      }
+
+    override def flatMap[A, B](fa: PotOption[A])(f: A => PotOption[B]): PotOption[B] =
+      fa.flatMap(f)
+
+    override def raiseError[A](t: Throwable): PotOption[A] = PotOption.Error(t)
+
+    override def handleErrorWith[A](fa: PotOption[A])(f: Throwable => PotOption[A]): PotOption[A] =
+      fa match {
+        case PotOption.Error(t) => f(t)
+        case _                  => fa
+      }
+
+    override def traverse[F[_], A, B](
+      fa: PotOption[A]
+    )(f:  A => F[B])(implicit F: Applicative[F]): F[PotOption[B]] =
+      fa match {
+        case PotOption.Pending        => F.pure(PotOption.Pending)
+        case err @ PotOption.Error(_) => F.pure(err.valueCast[B])
+        case PotOption.ReadyNone      => F.pure(PotOption.ReadyNone)
+        case PotOption.ReadySome(a)   => F.map(f(a))(PotOption.ReadySome(_))
+      }
+
+    override def foldLeft[A, B](fa: PotOption[A], b: B)(f: (B, A) => B): B =
+      fa match {
+        case PotOption.Pending      => b
+        case PotOption.Error(_)     => b
+        case PotOption.ReadyNone    => b
+        case PotOption.ReadySome(a) => f(b, a)
+      }
+
+    override def foldRight[A, B](fa: PotOption[A], lb: Eval[B])(
+      f:                             (A, Eval[B]) => Eval[B]
+    ): Eval[B] =
+      fa match {
+        case PotOption.Pending      => lb
+        case PotOption.Error(_)     => lb
+        case PotOption.ReadyNone    => lb
+        case PotOption.ReadySome(a) => f(a, lb)
+      }
+
+    override def functor: Functor[PotOption] = this
+
+    override def align[A, B](fa: PotOption[A], fb: PotOption[B]): PotOption[Ior[A, B]] =
+      alignWith(fa, fb)(identity)
+
+    override def alignWith[A, B, C](fa: PotOption[A], fb: PotOption[B])(
+      f:                                Ior[A, B] => C
+    ): PotOption[C] =
+      fa match {
+        case PotOption.Pending         =>
+          fb match {
+            case PotOption.ReadySome(b)    => PotOption.ReadySome(f(Ior.right(b)))
+            case errb @ PotOption.Error(_) => errb.valueCast[C]
+            case _                         => PotOption.Pending
+          }
+        case erra @ PotOption.Error(_) =>
+          fb match {
+            case PotOption.ReadySome(b) => PotOption.ReadySome(f(Ior.right(b)))
+            case _                      => erra.valueCast[C]
+          }
+        case PotOption.ReadyNone       =>
+          fb match {
+            case PotOption.Pending         => PotOption.Pending
+            case errb @ PotOption.Error(_) => errb.valueCast[C]
+            case PotOption.ReadyNone       => PotOption.ReadyNone
+            case PotOption.ReadySome(b)    => PotOption.ReadySome(f(Ior.right(b)))
+          }
+        case PotOption.ReadySome(a)    =>
+          fb match {
+            case PotOption.ReadySome(b) => PotOption.ReadySome(f(Ior.both(a, b)))
+            case _                      => PotOption.ReadySome(f(Ior.left(a)))
           }
       }
   }

--- a/shared/src/test/scala/crystal/PotOptionSpec.scala
+++ b/shared/src/test/scala/crystal/PotOptionSpec.scala
@@ -1,0 +1,179 @@
+package crystal
+
+import cats.kernel.laws.discipline.EqTests
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.laws.discipline._
+import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
+import crystal.implicits._
+import crystal.implicits.throwable._
+import monocle.law.discipline.PrismTests
+import munit.DisciplineSuite
+import org.scalacheck.Prop
+import org.scalacheck.Prop.forAll
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import arbitraries._
+
+class PotOptionSpec extends DisciplineSuite {
+  implicit def iso: Isomorphisms[PotOption] = Isomorphisms.invariant[PotOption]
+
+  checkAll(
+    "PotOptionSpec[Int].EqLaws",
+    EqTests[PotOption[Int]].eqv
+  )
+
+  checkAll(
+    "PotOption[Int].AlignLaws",
+    AlignTests[PotOption].align[Int, Int, Int, Int]
+  )
+
+  checkAll(
+    "PotOption[Int].MonadErrorLaws",
+    MonadErrorTests[PotOption, Throwable].monadError[Int, Int, String]
+  )
+
+  checkAll(
+    "PotOption[Int].TraverseLaws",
+    TraverseTests[PotOption].traverse[Int, Int, Int, Int, Option, Option]
+  )
+
+  checkAll(
+    "PotOption[Int].readySomePrism",
+    PrismTests(PotOption.readySomePrism[Int])
+  )
+
+  checkAll(
+    "PotOption[Int].errorPrism",
+    PrismTests(PotOption.errorPrism[Int])
+  )
+
+  property("Pending.toOption is None") {
+    PotOption.Pending.toOption.isEmpty
+  }
+
+  property("Pending.toOption is*") {
+    PotOption.Pending.isPending && !PotOption.Pending.isReady && !PotOption.Pending.isError && !PotOption.Pending.isDefined
+  }
+
+  property("PotOption[Int].toOption: Error(_) is None") {
+    forAll((t: Throwable) => PotOption.Error(t).toOption.isEmpty)
+  }
+
+  property("PotOption[Int].toOption: Error(_) is*") {
+    forAll((t: Throwable) =>
+      PotOption.Error(t).isError &&
+        !PotOption.Error(t).isReady &&
+        !PotOption.Error(t).isReady &&
+        !PotOption.Error(t).isDefined
+    )
+  }
+
+  property("ReadyNone.toOption is None") {
+    PotOption.ReadyNone.toOption.isEmpty
+  }
+
+  property("ReadyNone.toOption is*") {
+    !PotOption.ReadyNone.isPending && PotOption.ReadyNone.isReady && !PotOption.ReadyNone.isError & !PotOption.ReadyNone.isDefined
+  }
+
+  property("PotOption[Int].toOption: ReadySome(a) is Some(a)") {
+    forAll((i: Int) => PotOption.ReadySome(i).toOption === i.some)
+  }
+
+  property("PotOption[Int].toOption: Ready(a) is*") {
+    forAll((i: Int) =>
+      PotOption.ReadySome(i).isReady &&
+        !PotOption.ReadySome(i).isPending &&
+        !PotOption.ReadySome(i).isError &&
+        PotOption.ReadySome(i).isDefined
+    )
+  }
+
+  property("Pending.toOptionTry is None") {
+    PotOption.Pending.toOptionTry.isEmpty
+  }
+
+  property("PotOption[Int].toOptionTry: Error(t) is Some(Failure(t))") {
+    forAll((t: Throwable) => PotOption.error[Int](t).toOptionTry.contains_(Failure(t)))
+  }
+
+  property("PotOption[Int].toOptionTry: ReadySome(a) is Some(Success(a))") {
+    forAll((i: Int) => PotOption.ReadySome(i).toOptionTry === Success(i).some)
+  }
+
+  property("PotOption[Int] (Any.ready): a.ready === Ready(a)") {
+    forAll((i: Int) => i.ready === Pot.Ready(i))
+  }
+
+  property("PotOption[Int] (Option.toPotOption): None.toPotOption === ReadyNone") {
+    Prop(
+      none[Int].toPotOption match {
+        case PotOption.ReadyNone => true
+        case _                   => false
+      }
+    )
+  }
+
+  property("PotOption[Int] (Option.toPotOption): Some(a).toPotOption === ReadySome(a)") {
+    forAll((i: Int) => i.some.toPotOption === PotOption.ReadySome(i))
+  }
+
+  property("PotOption[Int] (Option[Try].toPotOption): None.toPotOption === Pending") {
+    Prop(
+      none[Try[Int]].toPotOption match {
+        case PotOption.Pending => true
+        case _                 => false
+      }
+    )
+  }
+
+  property(
+    "PotOption[Int] (Option[Try].toPotOption): Some(Failure[Int](t)).toPotOption === Error(t)"
+  ) {
+    forAll((t: Throwable) => Failure[Int](t).some.toPotOption === PotOption.Error(t))
+  }
+
+  property(
+    "PotOption[Int] (Option[Try].toPotOption): Some(Success(a).toPotOption) === ReadySome(a)"
+  ) {
+    forAll((i: Int) => Success(i).some.toPotOption === PotOption.ReadySome(i))
+  }
+
+  property("PotOption[Int] (Try.toPotOption): Failure[Int](t).toPotOption === Error(t)") {
+    forAll((t: Throwable) => Failure[Int](t).toPotOption === PotOption.Error(t))
+  }
+
+  property("PotOption[Int] (Try.toPotOption): Success(a).toPotOption === ReadySome(a)") {
+    forAll((i: Int) => Success(i).toPotOption === PotOption.ReadySome(i))
+  }
+
+  property("ReadySome(Pending).flatten === Pending") {
+    PotOption.ReadySome(PotOption.Pending).flatten === PotOption.Pending
+  }
+
+  property(
+    "PotOption[PotOption[Int]] (PotOption.flatten): ReadySome(ReadySome(a)).flatten === ReadySome(a)"
+  ) {
+    forAll((i: Int) =>
+      PotOption.ReadySome(PotOption.ReadySome(i)).flatten === PotOption.ReadySome(i)
+    )
+  }
+
+  property(
+    "PotOption[PotOption[Int]] (PotOption.flatten): ReadySome(ReadyNone).flatten === ReadyNone"
+  ) {
+    PotOption.ReadySome(PotOption.ReadyNone).flatten === PotOption.ReadyNone
+  }
+
+  property(
+    "PotOption[PotOption[Int]] (PotOption.flatten): ReadySome(Error(t)).flatten === Error(t)"
+  ) {
+    forAll { (t: Throwable) =>
+      PotOption[PotOption[Int]](PotOption.Error(t)).flatten === PotOption.Error(t)
+    }
+  }
+}

--- a/shared/src/test/scala/crystal/PotSpec.scala
+++ b/shared/src/test/scala/crystal/PotSpec.scala
@@ -47,100 +47,107 @@ class PotSpec extends DisciplineSuite {
   )
 
   checkAll(
-    "Pot[Int].pendingPrism",
-    PrismTests(Pot.pendingPrism[Int])
-  )
-
-  checkAll(
     "Pot[Int].errorPrism",
     PrismTests(Pot.errorPrism[Int])
   )
 
-  property("Pot[Int].toOption: Pending(_) is None") {
-    forAll((l: Long) => Pending(l).toOption.isEmpty)
+  property("Pending.toOption is None") {
+    Pot.Pending.toOption.isEmpty
   }
 
-  property("Pot[Int].toOption: Pending(_) isPending") {
-    forAll((l: Long) => Pending(l).isPending && !Pending(l).isReady && !Pending(l).isError)
+  property("Pending.toOption is*") {
+    Pot.Pending.isPending && !Pot.Pending.isReady && !Pot.Pending.isError
   }
 
   property("Pot[Int].toOption: Error(_) is None") {
-    forAll((t: Throwable) => Error(t).toOption.isEmpty)
+    forAll((t: Throwable) => Pot.Error(t).toOption.isEmpty)
   }
 
-  property("Pot[Int].toOption: Error(_) isError") {
-    forAll((t: Throwable) => Error(t).isError && !Error(t).isReady && !Error(t).isReady)
+  property("Pot[Int].toOption: Error(_) is*") {
+    forAll((t: Throwable) => Pot.Error(t).isError && !Pot.Error(t).isReady && !Pot.Error(t).isReady)
   }
 
   property("Pot[Int].toOption: Ready(a) is Some(a)") {
-    forAll((i: Int) => Ready(i).toOption === i.some)
+    forAll((i: Int) => Pot.Ready(i).toOption === i.some)
   }
 
-  property("Pot[Int].toOption: Ready(a) isReady") {
-    forAll((i: Int) => Ready(i).isReady && !Ready(i).isPending && !Ready(i).isError)
+  property("Pot[Int].toOption: Ready(a) is*") {
+    forAll((i: Int) => Pot.Ready(i).isReady && !Pot.Ready(i).isPending && !Pot.Ready(i).isError)
   }
 
-  property("Pot[Int].toTryOption: Pending(_) is None") {
-    forAll((l: Long) => Pending(l).toTryOption.isEmpty)
+  property("Pending.toOptionTry is None") {
+    Pot.Pending.toOptionTry.isEmpty
   }
 
-  property("Pot[Int].toTryOption: Error(t) is Some(Failure(t))") {
-    forAll((t: Throwable) => Pot.error[Int](t).toTryOption.contains_(Failure(t)))
+  property("Pot[Int].toOptionTry: Error(t) is Some(Failure(t))") {
+    forAll((t: Throwable) => Pot.error[Int](t).toOptionTry.contains_(Failure(t)))
   }
 
-  property("Pot[Int].toTryOption: Ready(a) is Some(Success(a))") {
-    forAll((i: Int) => Ready(i).toTryOption === Success(i).some)
+  property("Pot[Int].toOptionTry: Ready(a) is Some(Success(a))") {
+    forAll((i: Int) => Pot.Ready(i).toOptionTry === Success(i).some)
   }
 
   property("Pot[Int] (Any.ready): a.ready === Ready(a)") {
-    forAll((i: Int) => i.ready === Ready(i))
+    forAll((i: Int) => i.ready === Pot.Ready(i))
   }
 
-  property("Pot[Int] (Option.toPot): None.toPot === Pending(_)") {
+  property("Pot[Int] (Option.toPot): None.toPot === Pending") {
     Prop(
       none[Int].toPot match {
-        case Pending(_) => true
-        case _          => false
+        case Pot.Pending => true
+        case _           => false
       }
     )
   }
 
   property("Pot[Int] (Option.toPot): Some(a).toPot === Ready(a)") {
-    forAll((i: Int) => i.some.toPot === Ready(i))
+    forAll((i: Int) => i.some.toPot === Pot.Ready(i))
   }
 
-  property("Pot[Int] (Option[Try].toPot): None.toPot === Pending(_)") {
+  property("Pot[Int] (Option[Try].toPot): None.toPot === Pending") {
     Prop(
       none[Try[Int]].toPot match {
-        case Pending(_) => true
-        case _          => false
+        case Pot.Pending => true
+        case _           => false
       }
     )
   }
 
   property("Pot[Int] (Option[Try].toPot): Some(Failure[Int](t)).toPot === Error(t)") {
-    forAll((t: Throwable) => Failure[Int](t).some.toPot === Error(t))
+    forAll((t: Throwable) => Failure[Int](t).some.toPot === Pot.Error(t))
   }
 
   property("Pot[Int] (Option[Try].toPot): Some(Success(a).toPot) === Ready(a)") {
-    forAll((i: Int) => Success(i).some.toPot === Ready(i))
+    forAll((i: Int) => Success(i).some.toPot === Pot.Ready(i))
   }
 
   property("Pot[Int] (Try.toPot): Failure[Int](t).toPot === Error(t)") {
-    forAll((t: Throwable) => Failure[Int](t).toPot === Error(t))
+    forAll((t: Throwable) => Failure[Int](t).toPot === Pot.Error(t))
   }
 
   property("Pot[Int] (Try.toPot): Success(a).toPot === Ready(a)") {
-    forAll((i: Int) => Success(i).toPot === Ready(i))
+    forAll((i: Int) => Success(i).toPot === Pot.Ready(i))
+  }
+
+  property("Ready(Pending).flatten === Pending") {
+    Pot.Ready(Pot.Pending).flatten === Pot.Pending
   }
 
   property("Pot[Pot[Int]] (Pot.flatten): Ready(Ready(a)).flatten === Ready(a)") {
-    forAll((i: Int) => Ready(Ready(i)).flatten === Ready(i))
+    forAll((i: Int) => Pot.Ready(Pot.Ready(i)).flatten === Pot.Ready(i))
   }
 
   property("Pot[Pot[Int]] (Pot.flatten): Ready(Error(t)).flatten === Error(t)") {
     forAll { (t: Throwable) =>
-      Pot[Pot[Int]](Error(t)).flatten === Error(t)
+      Pot[Pot[Int]](Pot.Error(t)).flatten === Pot.Error(t)
     }
   }
+
+  // property("Ready(None).flatOpt === Pending") {
+  //   Pot.Ready(None).flatOpt == Pot.Pending
+  // }
+
+  // property("Pot[Option[Int]] (Pot.flatten): Ready(Some(a)).flatOpt === Ready(a)") {
+  //   forAll((i: Int) => Pot.Ready(Some(i)).flatOpt === Pot.Ready(i))
+  // }
 }

--- a/shared/src/test/scala/crystal/arbitraries.scala
+++ b/shared/src/test/scala/crystal/arbitraries.scala
@@ -9,14 +9,27 @@ object arbitraries {
   implicit def arbPot[A: Arbitrary]: Arbitrary[Pot[A]] =
     Arbitrary(
       oneOf(
-        arbitrary[Long].map(Pending.apply),
-        arbitrary[Throwable].map(Error.apply),
-        arbitrary[A].map(Ready.apply)
+        Gen.const(Pot.Pending),
+        arbitrary[Throwable].map(Pot.Error.apply),
+        arbitrary[A].map(Pot.Ready.apply)
       )
     )
 
   implicit def arbPotF[A](implicit fArb: Arbitrary[A => A]): Arbitrary[Pot[A] => Pot[A]] =
+    Arbitrary(arbitrary[A => A].map(f => _.map(f)))
+
+  implicit def arbPotOption[A: Arbitrary]: Arbitrary[PotOption[A]] =
     Arbitrary(
-      arbitrary[A => A].map(f => _.map(f))
+      oneOf(
+        Gen.const(PotOption.Pending),
+        arbitrary[Throwable].map(PotOption.Error.apply),
+        Gen.const(PotOption.ReadyNone),
+        arbitrary[A].map(PotOption.ReadySome.apply)
+      )
     )
+
+  implicit def arbPotOptionF[A](implicit
+    fArb: Arbitrary[A => A]
+  ): Arbitrary[PotOption[A] => PotOption[A]] =
+    Arbitrary(arbitrary[A => A].map(f => _.map(f)))
 }


### PR DESCRIPTION
**Justification:**
Sometimes, when we `useStream`, we want to differentiate between the states `"fiber hasn't started yet"` and `"fiber has started but nothing was received on the stream yet"`. This is especially useful when communicating with workers, where we want to send a request and make sure we don't miss the answer.

`Pot` proved insufficient for this since in both cases it presented a `Pending` value.

The solution is to use a `Pot[Option[A]]` where `Ready(None)` indicates when the fiber has started but there are no values yet. This proves to be cumbersome in client code though. (`_.map(_.map(...)))`. Using a monad transformer is cumbersome too. Hence, `PotOption` is born with 4 possible states: `Pending`, `Error(e)`, `ReadyNone`, `ReadySome(a)`.

**Corollary:**
Being able to differentiate between `Pending` and `ReadyNone` eliminates the need for all the `WithSync` versions of `useStream` and friends, which proved very cumbersome to use too.

We can now `useEffectWithDepsBy` with the `PotOption` as a dependency, and trigger initialization code `.whenA(potOption === PotOption.ReadyNone)`.

**Other changes:**
- `Pot` subtypes were moved inside `Pot` object, to differentiate them with similarly named types in `PotOption`.
- Starting time was removed from `Pending`. Reading `now()` implies `IO`, which isn't modeled. We don't use it anyway.